### PR TITLE
Fix the documented go generate command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,12 +14,14 @@ Three repos in play, all checked out side-by-side:
 Same constraint as goztl: this machine runs a binary blocker, so **do not invoke a local `go` toolchain**. Every Go command — build, test, format, `mod tidy`, `generate` — runs in a container.
 
 ```
-docker run --rm -v "$PWD":/src -w /src golang:1.25 go build ./...
-docker run --rm -v "$PWD":/src -w /src golang:1.25 go test ./...
-docker run --rm -v "$PWD":/src -w /src golang:1.25 gofmt -s -l .
-docker run --rm -v "$PWD":/src -w /src golang:1.25 go generate ./...
-docker run --rm -v "$PWD":/src -w /src golang:1.25 go mod tidy
+docker run --rm -v "$PWD":/terraform-provider-zentral -w /terraform-provider-zentral golang:1.25 go build ./...
+docker run --rm -v "$PWD":/terraform-provider-zentral -w /terraform-provider-zentral golang:1.25 go test ./...
+docker run --rm -v "$PWD":/terraform-provider-zentral -w /terraform-provider-zentral golang:1.25 gofmt -s -l .
+docker run --rm -v "$PWD":/terraform-provider-zentral -w /terraform-provider-zentral golang:1.25 go generate ./...
+docker run --rm -v "$PWD":/terraform-provider-zentral -w /terraform-provider-zentral golang:1.25 go mod tidy
 ```
+
+**The mount path has to keep the repository name.** `tfplugindocs` derives the provider name from the working directory, so mounting at `/src` makes it look for a `src_zentral_…` provider, fail — and, because it wipes `docs/` before rendering, leave the whole directory deleted. Recover with `git checkout -- docs/`. The other commands don't care, but they use the same path so there is one invocation to remember.
 
 A devcontainer (`mcr.microsoft.com/devcontainers/go:1.24`) is also configured for an interactive shell inside the container.
 
@@ -94,12 +96,12 @@ Almost always preceded by a goztl release — the provider depends on a typed se
 
 ## Running things
 
-**Build / install locally:** `docker run --rm -v "$PWD":/src -w /src golang:1.25 go install` drops the binary in the container's `$GOPATH/bin`. For driving Terraform against a local build, the standard `~/.terraformrc` `dev_overrides` mechanism is the way.
+**Build / install locally:** `docker run --rm -v "$PWD":/terraform-provider-zentral -w /terraform-provider-zentral golang:1.25 go install` drops the binary in the container's `$GOPATH/bin`. For driving Terraform against a local build, the standard `~/.terraformrc` `dev_overrides` mechanism is the way.
 
 **Acceptance tests** require `TF_ACC=1` and a reachable Zentral:
 
 ```
-docker run --rm -v "$PWD":/src -w /src \
+docker run --rm -v "$PWD":/terraform-provider-zentral -w /terraform-provider-zentral \
   -e TF_ACC=1 \
   -e ZTL_API_BASE_URL="$ZTL_API_BASE_URL" \
   -e ZTL_API_TOKEN="$ZTL_API_TOKEN" \


### PR DESCRIPTION
`tfplugindocs` derives the provider name from the working directory. With the documented `-v "$PWD":/src -w /src` mount it looks for a `src_zentral_gws_connection` data source, doesn't find it, and errors:

```
data source entitled "src", or "src_zentral_gws_connection" does not exist
Error executing command: unable to generate website: ...
```

The damage is that it empties `docs/` *before* rendering, so the failed run leaves the whole directory deleted in the working tree — recoverable with `git checkout -- docs/`, but only once you realise what happened.

Mounting at the repository name fixes it. I moved every command in the file to the same mount path rather than leave `generate` as the odd one out, and added a note so it doesn't get "simplified" back.

Verified on a clean checkout of `main`: the command as documented now renders every template and leaves a zero diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)