### PR TITLE
Fix the enrollment quota description

### DIFF
--- a/docs/data-sources/mdm_ota_enrollment.md
+++ b/docs/data-sources/mdm_ota_enrollment.md
@@ -27,7 +27,7 @@ The data source `zentral_mdm_ota_enrollment` allows details of a MDM OTA enrollm
 - `display_name` (String) Name of the MDM OTA enrollment as displayed on the device.
 - `meta_business_unit_id` (Number) The `ID` of the meta business unit the machine will be assigned to at enrollment.
 - `push_certificate_id` (Number) `ID` of the MDM push certificate linked to the OTA enrollment.
-- `quota` (Number) The number of time the enrollment can be used.
+- `quota` (Number) The number of times the enrollment can be used.
 - `realm_uuid` (String) `UUID` of the identity realm linked to the OTA enrollment.
 - `scep_issuer_id` (String) `ID` of the MDM SCEP issuer linked to the OTA enrollment.
 - `secret` (String) Enrollment secret.

--- a/docs/data-sources/monolith_enrollment.md
+++ b/docs/data-sources/monolith_enrollment.md
@@ -25,7 +25,7 @@ The data source `zentral_monolith_enrollment` allows details of a Monolith enrol
 - `manifest_id` (Number) `ID` of the Monolith manifest.
 - `meta_business_unit_id` (Number) The `ID` of the meta business unit the machine will be assigned to at enrollment.
 - `plist_url` (String) Plist download URL.
-- `quota` (Number) The number of time the enrollment can be used.
+- `quota` (Number) The number of times the enrollment can be used.
 - `secret` (String) Enrollment secret.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.

--- a/docs/data-sources/munki_enrollment.md
+++ b/docs/data-sources/munki_enrollment.md
@@ -24,7 +24,7 @@ The data source `zentral_munki_enrollment` allows details of a Munki enrollment 
 - `configuration_id` (Number) `ID` of the Munki configuration.
 - `meta_business_unit_id` (Number) The `ID` of the meta business unit the machine will be assigned to at enrollment.
 - `package_url` (String) Package download URL.
-- `quota` (Number) The number of time the enrollment can be used.
+- `quota` (Number) The number of times the enrollment can be used.
 - `secret` (String) Enrollment secret.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.

--- a/docs/data-sources/osquery_enrollment.md
+++ b/docs/data-sources/osquery_enrollment.md
@@ -26,7 +26,7 @@ The data source `zentral_osquery_enrollment` allows details of a Osquery enrollm
 - `osquery_release` (String) Osquery release to include in the enrollment artifacts.
 - `package_url` (String) macOS package download URL.
 - `powershell_script_url` (String) Powershell script download URL.
-- `quota` (Number) The number of time the enrollment can be used.
+- `quota` (Number) The number of times the enrollment can be used.
 - `script_url` (String) Linux script download URL.
 - `secret` (String) Enrollment secret.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.

--- a/docs/data-sources/santa_enrollment.md
+++ b/docs/data-sources/santa_enrollment.md
@@ -25,7 +25,7 @@ The data source `zentral_santa_enrollment` allows details of a Santa enrollment 
 - `configuration_profile_url` (String) Configuration profile download URL.
 - `meta_business_unit_id` (Number) The `ID` of the meta business unit the machine will be assigned to at enrollment.
 - `plist_url` (String) Plist download URL.
-- `quota` (Number) The number of time the enrollment can be used.
+- `quota` (Number) The number of times the enrollment can be used.
 - `secret` (String) Enrollment secret.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.

--- a/docs/resources/mdm_ota_enrollment.md
+++ b/docs/resources/mdm_ota_enrollment.md
@@ -27,7 +27,7 @@ The resource `zentral_mdm_ota_enrollment` manages MDM OTA enrollments.
 - `acme_issuer_id` (String) `ID` of the optional MDM ACME issuer linked to the OTA enrollment.
 - `blueprint_id` (Number) `ID` of the MDM blueprint linked to the OTA enrollment.
 - `display_name` (String) Name of the MDM OTA enrollment as displayed on the device.
-- `quota` (Number) The number of time the enrollment can be used.
+- `quota` (Number) The number of times the enrollment can be used.
 - `realm_uuid` (String) `UUID` of the identity realm linked to the OTA enrollment.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.

--- a/docs/resources/monolith_enrollment.md
+++ b/docs/resources/monolith_enrollment.md
@@ -22,7 +22,7 @@ The resource `zentral_monolith_enrollment` manages Monolith enrollments.
 
 ### Optional
 
-- `quota` (Number) The number of time the enrollment can be used.
+- `quota` (Number) The number of times the enrollment can be used.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.
 - `udids` (Set of String) The `UDID`s the enrollment is restricted to.

--- a/docs/resources/munki_enrollment.md
+++ b/docs/resources/munki_enrollment.md
@@ -22,7 +22,7 @@ The resource `zentral_munki_enrollment` manages Munki enrollments.
 
 ### Optional
 
-- `quota` (Number) The number of time the enrollment can be used.
+- `quota` (Number) The number of times the enrollment can be used.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.
 - `udids` (Set of String) The `UDID`s the enrollment is restricted to.

--- a/docs/resources/osquery_enrollment.md
+++ b/docs/resources/osquery_enrollment.md
@@ -23,7 +23,7 @@ The resource `zentral_osquery_enrollment` manages Osquery enrollments.
 ### Optional
 
 - `osquery_release` (String) Osquery release to include in the enrollment artifacts.
-- `quota` (Number) The number of time the enrollment can be used.
+- `quota` (Number) The number of times the enrollment can be used.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.
 - `udids` (Set of String) The `UDID`s the enrollment is restricted to.

--- a/docs/resources/santa_enrollment.md
+++ b/docs/resources/santa_enrollment.md
@@ -22,7 +22,7 @@ The resource `zentral_santa_enrollment` manages Santa enrollments.
 
 ### Optional
 
-- `quota` (Number) The number of time the enrollment can be used.
+- `quota` (Number) The number of times the enrollment can be used.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.
 - `udids` (Set of String) The `UDID`s the enrollment is restricted to.

--- a/internal/provider/mdm_ota_enrollment_data_source.go
+++ b/internal/provider/mdm_ota_enrollment_data_source.go
@@ -101,8 +101,8 @@ func (d *MDMOTAEnrollmentDataSource) Schema(ctx context.Context, req datasource.
 				Computed:            true,
 			},
 			"quota": schema.Int64Attribute{
-				Description:         "The number of time the enrollment can be used.",
-				MarkdownDescription: "The number of time the enrollment can be used.",
+				Description:         "The number of times the enrollment can be used.",
+				MarkdownDescription: "The number of times the enrollment can be used.",
 				Computed:            true,
 			},
 		},

--- a/internal/provider/mdm_ota_enrollment_resource.go
+++ b/internal/provider/mdm_ota_enrollment_resource.go
@@ -117,8 +117,8 @@ func (r *MDMOTAEnrollmentResource) Schema(ctx context.Context, req resource.Sche
 				Computed:            true,
 			},
 			"quota": schema.Int64Attribute{
-				Description:         "The number of time the enrollment can be used.",
-				MarkdownDescription: "The number of time the enrollment can be used.",
+				Description:         "The number of times the enrollment can be used.",
+				MarkdownDescription: "The number of times the enrollment can be used.",
 				Optional:            true,
 			},
 		},

--- a/internal/provider/monolith_enrollment_data_source.go
+++ b/internal/provider/monolith_enrollment_data_source.go
@@ -86,8 +86,8 @@ func (d *MonolithEnrollmentDataSource) Schema(ctx context.Context, req datasourc
 				Computed:            true,
 			},
 			"quota": schema.Int64Attribute{
-				Description:         "The number of time the enrollment can be used.",
-				MarkdownDescription: "The number of time the enrollment can be used.",
+				Description:         "The number of times the enrollment can be used.",
+				MarkdownDescription: "The number of times the enrollment can be used.",
 				Computed:            true,
 			},
 		},

--- a/internal/provider/monolith_enrollment_resource.go
+++ b/internal/provider/monolith_enrollment_resource.go
@@ -96,8 +96,8 @@ func (r *MonolithEnrollmentResource) Schema(ctx context.Context, req resource.Sc
 				Computed:            true,
 			},
 			"quota": schema.Int64Attribute{
-				Description:         "The number of time the enrollment can be used.",
-				MarkdownDescription: "The number of time the enrollment can be used.",
+				Description:         "The number of times the enrollment can be used.",
+				MarkdownDescription: "The number of times the enrollment can be used.",
 				Optional:            true,
 			},
 		},

--- a/internal/provider/munki_enrollment_data_source.go
+++ b/internal/provider/munki_enrollment_data_source.go
@@ -81,8 +81,8 @@ func (d *MunkiEnrollmentDataSource) Schema(ctx context.Context, req datasource.S
 				Computed:            true,
 			},
 			"quota": schema.Int64Attribute{
-				Description:         "The number of time the enrollment can be used.",
-				MarkdownDescription: "The number of time the enrollment can be used.",
+				Description:         "The number of times the enrollment can be used.",
+				MarkdownDescription: "The number of times the enrollment can be used.",
 				Computed:            true,
 			},
 		},

--- a/internal/provider/munki_enrollment_resource.go
+++ b/internal/provider/munki_enrollment_resource.go
@@ -91,8 +91,8 @@ func (r *MunkiEnrollmentResource) Schema(ctx context.Context, req resource.Schem
 				Computed:            true,
 			},
 			"quota": schema.Int64Attribute{
-				Description:         "The number of time the enrollment can be used.",
-				MarkdownDescription: "The number of time the enrollment can be used.",
+				Description:         "The number of times the enrollment can be used.",
+				MarkdownDescription: "The number of times the enrollment can be used.",
 				Optional:            true,
 			},
 		},

--- a/internal/provider/osquery_enrollment_data_source.go
+++ b/internal/provider/osquery_enrollment_data_source.go
@@ -96,8 +96,8 @@ func (d *OsqueryEnrollmentDataSource) Schema(ctx context.Context, req datasource
 				Computed:            true,
 			},
 			"quota": schema.Int64Attribute{
-				Description:         "The number of time the enrollment can be used.",
-				MarkdownDescription: "The number of time the enrollment can be used.",
+				Description:         "The number of times the enrollment can be used.",
+				MarkdownDescription: "The number of times the enrollment can be used.",
 				Computed:            true,
 			},
 		},

--- a/internal/provider/osquery_enrollment_resource.go
+++ b/internal/provider/osquery_enrollment_resource.go
@@ -109,8 +109,8 @@ func (r *OsqueryEnrollmentResource) Schema(ctx context.Context, req resource.Sch
 				Computed:            true,
 			},
 			"quota": schema.Int64Attribute{
-				Description:         "The number of time the enrollment can be used.",
-				MarkdownDescription: "The number of time the enrollment can be used.",
+				Description:         "The number of times the enrollment can be used.",
+				MarkdownDescription: "The number of times the enrollment can be used.",
 				Optional:            true,
 			},
 		},

--- a/internal/provider/santa_enrollment_data_source.go
+++ b/internal/provider/santa_enrollment_data_source.go
@@ -86,8 +86,8 @@ func (d *SantaEnrollmentDataSource) Schema(ctx context.Context, req datasource.S
 				Computed:            true,
 			},
 			"quota": schema.Int64Attribute{
-				Description:         "The number of time the enrollment can be used.",
-				MarkdownDescription: "The number of time the enrollment can be used.",
+				Description:         "The number of times the enrollment can be used.",
+				MarkdownDescription: "The number of times the enrollment can be used.",
 				Computed:            true,
 			},
 		},

--- a/internal/provider/santa_enrollment_resource.go
+++ b/internal/provider/santa_enrollment_resource.go
@@ -96,8 +96,8 @@ func (r *SantaEnrollmentResource) Schema(ctx context.Context, req resource.Schem
 				Computed:            true,
 			},
 			"quota": schema.Int64Attribute{
-				Description:         "The number of time the enrollment can be used.",
-				MarkdownDescription: "The number of time the enrollment can be used.",
+				Description:         "The number of times the enrollment can be used.",
+				MarkdownDescription: "The number of times the enrollment can be used.",
 				Optional:            true,
 			},
 		},


### PR DESCRIPTION
`quota` reads "The number of time the enrollment can be used." in the MDM OTA, Monolith, Munki, Osquery and Santa enrollments — in the resource and in the data source, in both `Description` and `MarkdownDescription`, so it reaches the generated docs.

The shared enrollment secret schema in `enrollment.go` already had it right, which is what makes the inconsistency visible.

Text only: 10 source files, 10 regenerated doc pages, no schema keys or behaviour touched.

(The Turbo enrollment had the same typo, inherited from the copy it was based on; it is fixed in [#255](https://github.com/zentralopensource/terraform-provider-zentral/pull/255).)

🤖 Generated with [Claude Code](https://claude.com/claude-code)