### PR TITLE
Add the MDM reveal rotation delays

### DIFF
--- a/docs/data-sources/mdm_filevault_config.md
+++ b/docs/data-sources/mdm_filevault_config.md
@@ -26,5 +26,6 @@ The data source `zentral_mdm_filevault_config` allows details of a MDM FileVault
 - `bypass_attempts` (Number) The maximum number of times users can bypass enabling FileVault before being required to enable it to log in.
 - `destroy_key_on_standby` (Boolean) Set to `true` to prevent storing the FileVault key across restarts. Defaults to `false`.
 - `escrow_location_display_name` (String) Description of the location where the FDE PRK will be escrowed. This text will be inserted into the message the user sees when enabling FileVault.
+- `prk_reveal_rotation_delay` (Number) The delay in minutes after which a PRK rotation is scheduled once the PRK has been revealed.
 - `prk_rotation_interval_days` (Number) The automatic PRK rotation interval in days. It has a maximum value of `365`. Defaults to `0` (no automatic rotation).
 - `show_recovery_key` (Boolean) If `false`, prevents display of the personal recovery key to the user after FileVault is enabled. Defaults to `false`.

--- a/docs/data-sources/mdm_recovery_password_config.md
+++ b/docs/data-sources/mdm_recovery_password_config.md
@@ -23,6 +23,7 @@ The data source `zentral_mdm_recovery_password_config` allows details of a MDM r
 ### Read-Only
 
 - `dynamic_password` (Boolean) If `true`, a unique password is generated for each device. Defaults to `true`.
+- `reveal_rotation_delay` (Number) The delay in minutes after which a recovery password rotation is scheduled once the password has been revealed.
 - `rotate_firmware_password` (Boolean) Set to `true` to rotate the firmware passwords. Defaults to `false`.
 - `rotation_interval_days` (Number) The automatic recovery password rotation interval in days. It has a maximum value of `365`. Defaults to `0` (no automatic rotation).
 - `static_password` (String) The  static password to set for all devices.

--- a/docs/resources/mdm_filevault_config.md
+++ b/docs/resources/mdm_filevault_config.md
@@ -25,6 +25,7 @@ The resource `zentral_mdm_filevault_config` manages MDM FileVault configurations
 - `at_login_only` (Boolean) If `true`, prevents requests for enabling FileVault at user logout time. Defaults to `false`.
 - `bypass_attempts` (Number) The maximum number of times users can bypass enabling FileVault before being required to enable it to log in.
 - `destroy_key_on_standby` (Boolean) Set to `true` to prevent storing the FileVault key across restarts. Defaults to `false`.
+- `prk_reveal_rotation_delay` (Number) The delay in minutes after which a PRK rotation is scheduled once the PRK has been revealed. Must be `0`, or between `5` and `1440`. Defaults to `0` (no rotation after a reveal). Note that a configuration created outside of Terraform defaults to `60`.
 - `prk_rotation_interval_days` (Number) The automatic PRK rotation interval in days. It has a maximum value of `365`. Defaults to `0` (no automatic rotation).
 - `show_recovery_key` (Boolean) If `false`, prevents display of the personal recovery key to the user after FileVault is enabled. Defaults to `false`.
 

--- a/docs/resources/mdm_recovery_password_config.md
+++ b/docs/resources/mdm_recovery_password_config.md
@@ -22,6 +22,7 @@ The resource `zentral_mdm_recovery_password_config` manages MDM recovery passwor
 ### Optional
 
 - `dynamic_password` (Boolean) If `true`, a unique password is generated for each device. Defaults to `true`.
+- `reveal_rotation_delay` (Number) The delay in minutes after which a recovery password rotation is scheduled once the password has been revealed. Must be `0`, or between `5` and `1440`, and must be `0` with a static password. Defaults to `0` (no rotation after a reveal). Note that a configuration created outside of Terraform defaults to `60`.
 - `rotate_firmware_password` (Boolean) Set to `true` to rotate the firmware passwords. Defaults to `false`.
 - `rotation_interval_days` (Number) The automatic recovery password rotation interval in days. It has a maximum value of `365`. Defaults to `0` (no automatic rotation).
 - `static_password` (String) The  static password to set for all devices.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
-	github.com/zentralopensource/goztl v0.1.74
+	github.com/zentralopensource/goztl v0.1.76
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,8 @@ github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 github.com/zentralopensource/goztl v0.1.74 h1:HYHlPteL+Xfg30ITRPJOT+B9JluKaxJBRVsoChSEETw=
 github.com/zentralopensource/goztl v0.1.74/go.mod h1:v7QVp73QeJM1WRffCmxzMEd/2q1K33050U2aep+fYD0=
+github.com/zentralopensource/goztl v0.1.76 h1:jYwpG7HWknAnmeHyi58aCXxFkqD+JQdW7bE9sk1YuLA=
+github.com/zentralopensource/goztl v0.1.76/go.mod h1:v7QVp73QeJM1WRffCmxzMEd/2q1K33050U2aep+fYD0=
 go.abhg.dev/goldmark/frontmatter v0.2.0 h1:P8kPG0YkL12+aYk2yU3xHv4tcXzeVnN+gU0tJ5JnxRw=
 go.abhg.dev/goldmark/frontmatter v0.2.0/go.mod h1:XqrEkZuM57djk7zrlRUB02x8I5J0px76YjkOzhB4YlU=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/provider/mdm_filevault_config.go
+++ b/internal/provider/mdm_filevault_config.go
@@ -14,6 +14,7 @@ type mdmFileVaultConfig struct {
 	ShowRecoveryKey           types.Bool   `tfsdk:"show_recovery_key"`
 	DestroyKeyOnStandby       types.Bool   `tfsdk:"destroy_key_on_standby"`
 	PRKRotationIntervalDays   types.Int64  `tfsdk:"prk_rotation_interval_days"`
+	PRKRevealRotationDelay    types.Int64  `tfsdk:"prk_reveal_rotation_delay"`
 }
 
 func mdmFileVaultConfigForState(mfc *goztl.MDMFileVaultConfig) mdmFileVaultConfig {
@@ -26,6 +27,7 @@ func mdmFileVaultConfigForState(mfc *goztl.MDMFileVaultConfig) mdmFileVaultConfi
 		ShowRecoveryKey:           types.BoolValue(mfc.ShowRecoveryKey),
 		DestroyKeyOnStandby:       types.BoolValue(mfc.DestroyKeyOnStandby),
 		PRKRotationIntervalDays:   types.Int64Value(int64(mfc.PRKRotationIntervalDays)),
+		PRKRevealRotationDelay:    types.Int64Value(int64(mfc.PRKRevealRotationDelay)),
 	}
 }
 
@@ -38,5 +40,6 @@ func mdmFileVaultConfigRequestWithState(data mdmFileVaultConfig) *goztl.MDMFileV
 		ShowRecoveryKey:           data.ShowRecoveryKey.ValueBool(),
 		DestroyKeyOnStandby:       data.DestroyKeyOnStandby.ValueBool(),
 		PRKRotationIntervalDays:   int(data.PRKRotationIntervalDays.ValueInt64()),
+		PRKRevealRotationDelay:    int(data.PRKRevealRotationDelay.ValueInt64()),
 	}
 }

--- a/internal/provider/mdm_filevault_config_data_source.go
+++ b/internal/provider/mdm_filevault_config_data_source.go
@@ -71,6 +71,11 @@ func (d *MDMFileVaultConfigDataSource) Schema(ctx context.Context, req datasourc
 				MarkdownDescription: "The automatic PRK rotation interval in days. It has a maximum value of `365`. Defaults to `0` (no automatic rotation).",
 				Computed:            true,
 			},
+			"prk_reveal_rotation_delay": schema.Int64Attribute{
+				Description:         "The delay in minutes after which a PRK rotation is scheduled once the PRK has been revealed.",
+				MarkdownDescription: "The delay in minutes after which a PRK rotation is scheduled once the PRK has been revealed.",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/mdm_filevault_config_data_source_test.go
+++ b/internal/provider/mdm_filevault_config_data_source_test.go
@@ -38,6 +38,8 @@ func TestAccMDMFileVaultConfigDataSource(t *testing.T) {
 						ds1ResourceName, "destroy_key_on_standby", "false"),
 					resource.TestCheckResourceAttr(
 						ds1ResourceName, "prk_rotation_interval_days", "0"),
+					resource.TestCheckResourceAttr(
+						ds1ResourceName, "prk_reveal_rotation_delay", "0"),
 					// Read by ID
 					resource.TestCheckResourceAttrPair(
 						ds2ResourceName, "id", c2ResourceName, "id"),
@@ -53,6 +55,8 @@ func TestAccMDMFileVaultConfigDataSource(t *testing.T) {
 						ds2ResourceName, "destroy_key_on_standby", "true"),
 					resource.TestCheckResourceAttr(
 						ds2ResourceName, "prk_rotation_interval_days", "90"),
+					resource.TestCheckResourceAttr(
+						ds2ResourceName, "prk_reveal_rotation_delay", "120"),
 				),
 			},
 		},
@@ -74,6 +78,7 @@ resource "zentral_mdm_filevault_config" "check2" {
   show_recovery_key            = true
   destroy_key_on_standby       = true
   prk_rotation_interval_days   = 90
+  prk_reveal_rotation_delay    = 120
 }
 
 data "zentral_mdm_filevault_config" "check1_by_name" {

--- a/internal/provider/mdm_filevault_config_resource.go
+++ b/internal/provider/mdm_filevault_config_resource.go
@@ -98,6 +98,23 @@ func (r *MDMFileVaultConfigResource) Schema(ctx context.Context, req resource.Sc
 					int64validator.Between(0, 365),
 				},
 			},
+			"prk_reveal_rotation_delay": schema.Int64Attribute{
+				Description: "The delay in minutes after which a PRK rotation is scheduled once the PRK has been revealed. " +
+					"Must be 0, or between 5 and 1440. Defaults to 0 (no rotation after a reveal). " +
+					"Note that a configuration created outside of Terraform defaults to 60.",
+				MarkdownDescription: "The delay in minutes after which a PRK rotation is scheduled once the PRK has been revealed. " +
+					"Must be `0`, or between `5` and `1440`. Defaults to `0` (no rotation after a reveal). " +
+					"Note that a configuration created outside of Terraform defaults to `60`.",
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(0),
+				Validators: []validator.Int64{
+					int64validator.Any(
+						int64validator.OneOf(0),
+						int64validator.Between(5, 1440),
+					),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/mdm_filevault_config_resource_test.go
+++ b/internal/provider/mdm_filevault_config_resource_test.go
@@ -37,6 +37,8 @@ func TestAccMDMFileVaultConfigResource(t *testing.T) {
 						resourceName, "destroy_key_on_standby", "false"),
 					resource.TestCheckResourceAttr(
 						resourceName, "prk_rotation_interval_days", "0"),
+					resource.TestCheckResourceAttr(
+						resourceName, "prk_reveal_rotation_delay", "0"),
 				),
 			},
 			// ImportState
@@ -63,6 +65,8 @@ func TestAccMDMFileVaultConfigResource(t *testing.T) {
 						resourceName, "destroy_key_on_standby", "true"),
 					resource.TestCheckResourceAttr(
 						resourceName, "prk_rotation_interval_days", "90"),
+					resource.TestCheckResourceAttr(
+						resourceName, "prk_reveal_rotation_delay", "120"),
 				),
 			},
 			// ImportState
@@ -94,6 +98,7 @@ resource "zentral_mdm_filevault_config" "test" {
   show_recovery_key            = true
   destroy_key_on_standby       = true
   prk_rotation_interval_days   = 90
+  prk_reveal_rotation_delay    = 120
 }
 `, name, escName)
 }

--- a/internal/provider/mdm_recovery_password_config.go
+++ b/internal/provider/mdm_recovery_password_config.go
@@ -11,6 +11,7 @@ type mdmRecoveryPasswordConfig struct {
 	DynamicPassword        types.Bool   `tfsdk:"dynamic_password"`
 	StaticPassword         types.String `tfsdk:"static_password"`
 	RotationIntervalDays   types.Int64  `tfsdk:"rotation_interval_days"`
+	RevealRotationDelay    types.Int64  `tfsdk:"reveal_rotation_delay"`
 	RotateFirmwarePassword types.Bool   `tfsdk:"rotate_firmware_password"`
 }
 
@@ -28,6 +29,7 @@ func mdmRecoveryPasswordConfigForState(mrpc *goztl.MDMRecoveryPasswordConfig) md
 		DynamicPassword:        types.BoolValue(mrpc.DynamicPassword),
 		StaticPassword:         staticPassword,
 		RotationIntervalDays:   types.Int64Value(int64(mrpc.RotationIntervalDays)),
+		RevealRotationDelay:    types.Int64Value(int64(mrpc.RevealRotationDelay)),
 		RotateFirmwarePassword: types.BoolValue(mrpc.RotateFirmwarePassword),
 	}
 }
@@ -43,6 +45,7 @@ func mdmRecoveryPasswordConfigRequestWithState(data mdmRecoveryPasswordConfig) *
 		DynamicPassword:        data.DynamicPassword.ValueBool(),
 		StaticPassword:         staticPassword,
 		RotationIntervalDays:   int(data.RotationIntervalDays.ValueInt64()),
+		RevealRotationDelay:    int(data.RevealRotationDelay.ValueInt64()),
 		RotateFirmwarePassword: data.RotateFirmwarePassword.ValueBool(),
 	}
 }

--- a/internal/provider/mdm_recovery_password_config_data_source.go
+++ b/internal/provider/mdm_recovery_password_config_data_source.go
@@ -56,6 +56,11 @@ func (d *MDMRecoveryPasswordConfigDataSource) Schema(ctx context.Context, req da
 				MarkdownDescription: "The automatic recovery password rotation interval in days. It has a maximum value of `365`. Defaults to `0` (no automatic rotation).",
 				Computed:            true,
 			},
+			"reveal_rotation_delay": schema.Int64Attribute{
+				Description:         "The delay in minutes after which a recovery password rotation is scheduled once the password has been revealed.",
+				MarkdownDescription: "The delay in minutes after which a recovery password rotation is scheduled once the password has been revealed.",
+				Computed:            true,
+			},
 			"rotate_firmware_password": schema.BoolAttribute{
 				Description:         "Set to true to rotate the firmware passwords. Defaults to false.",
 				MarkdownDescription: "Set to `true` to rotate the firmware passwords. Defaults to `false`.",

--- a/internal/provider/mdm_recovery_password_config_data_source_test.go
+++ b/internal/provider/mdm_recovery_password_config_data_source_test.go
@@ -33,6 +33,8 @@ func TestAccMDMRecoveryPasswordConfigDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						ds1ResourceName, "rotation_interval_days", "90"),
 					resource.TestCheckResourceAttr(
+						ds1ResourceName, "reveal_rotation_delay", "120"),
+					resource.TestCheckResourceAttr(
 						ds1ResourceName, "rotate_firmware_password", "true"),
 					// Read by ID
 					resource.TestCheckResourceAttrPair(
@@ -43,6 +45,8 @@ func TestAccMDMRecoveryPasswordConfigDataSource(t *testing.T) {
 						ds2ResourceName, "static_password", "12345678"),
 					resource.TestCheckResourceAttr(
 						ds2ResourceName, "rotation_interval_days", "0"),
+					resource.TestCheckResourceAttr(
+						ds2ResourceName, "reveal_rotation_delay", "0"),
 					resource.TestCheckResourceAttr(
 						ds2ResourceName, "rotate_firmware_password", "false"),
 				),
@@ -56,6 +60,7 @@ func testAccMDMRecoveryPasswordConfigDataSourceConfig(c1Name string, c2Name stri
 resource "zentral_mdm_recovery_password_config" "check1" {
   name                     = %[1]q
   rotation_interval_days   = 90
+  reveal_rotation_delay    = 120
   rotate_firmware_password = true
 }
 

--- a/internal/provider/mdm_recovery_password_config_resource.go
+++ b/internal/provider/mdm_recovery_password_config_resource.go
@@ -74,6 +74,25 @@ func (r *MDMRecoveryPasswordConfigResource) Schema(ctx context.Context, req reso
 					int64validator.Between(0, 365),
 				},
 			},
+			"reveal_rotation_delay": schema.Int64Attribute{
+				Description: "The delay in minutes after which a recovery password rotation is scheduled once the password " +
+					"has been revealed. Must be 0, or between 5 and 1440, and must be 0 with a static password. " +
+					"Defaults to 0 (no rotation after a reveal). " +
+					"Note that a configuration created outside of Terraform defaults to 60.",
+				MarkdownDescription: "The delay in minutes after which a recovery password rotation is scheduled once the password " +
+					"has been revealed. Must be `0`, or between `5` and `1440`, and must be `0` with a static password. " +
+					"Defaults to `0` (no rotation after a reveal). " +
+					"Note that a configuration created outside of Terraform defaults to `60`.",
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(0),
+				Validators: []validator.Int64{
+					int64validator.Any(
+						int64validator.OneOf(0),
+						int64validator.Between(5, 1440),
+					),
+				},
+			},
 			"rotate_firmware_password": schema.BoolAttribute{
 				Description:         "Set to true to rotate the firmware passwords. Defaults to false.",
 				MarkdownDescription: "Set to `true` to rotate the firmware passwords. Defaults to `false`.",

--- a/internal/provider/mdm_recovery_password_config_resource_test.go
+++ b/internal/provider/mdm_recovery_password_config_resource_test.go
@@ -30,6 +30,8 @@ func TestAccMDMRecoveryPasswordConfigResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "rotation_interval_days", "90"),
 					resource.TestCheckResourceAttr(
+						resourceName, "reveal_rotation_delay", "120"),
+					resource.TestCheckResourceAttr(
 						resourceName, "rotate_firmware_password", "true"),
 				),
 			},
@@ -51,6 +53,9 @@ func TestAccMDMRecoveryPasswordConfigResource(t *testing.T) {
 						resourceName, "static_password", "12345678"),
 					resource.TestCheckResourceAttr(
 						resourceName, "rotation_interval_days", "0"),
+					// a static password forbids a rotation after reveal: the 0 default keeps it valid
+					resource.TestCheckResourceAttr(
+						resourceName, "reveal_rotation_delay", "0"),
 					resource.TestCheckResourceAttr(
 						resourceName, "rotate_firmware_password", "false"),
 				),
@@ -70,6 +75,7 @@ func testAccMDMRecoveryPasswordConfigResourceConfigDynamic(name string) string {
 resource "zentral_mdm_recovery_password_config" "test" {
   name                     = %[1]q
   rotation_interval_days   = 90
+  reveal_rotation_delay    = 120
   rotate_firmware_password = true
 }
 `, name)


### PR DESCRIPTION
Unblocks CI.

[zentral#1575](https://github.com/zentralopensource/zentral/pull/1575) added two `NOT NULL` columns — `mdm_filevaultconfig.prk_reveal_rotation_delay` and `mdm_recoverypasswordconfig.reveal_rotation_delay` — and exposed both through the API. Until the client sends them, every creation is a 500:

```
POST /api/mdm/filevault_configs/: 500 IntegrityError
null value in column "prk_reveal_rotation_delay" violates not-null constraint
```

That was failing `TestAccMDMFileVaultConfig*`, `TestAccMDMRecoveryPasswordConfig*` and, through the blueprints, `TestAccMDMBlueprint*` — 7 tests.

Requires goztl [v0.1.76](https://github.com/zentralopensource/goztl/releases/tag/v0.1.76) ([#83](https://github.com/zentralopensource/goztl/pull/83)), which carries the fields.

## The default is 0, not 60

The API defaults both to `60`, but this provider defaults them to `0`, deliberately:

- #1575's data migration set **existing rows to 0** — *"existing configurations keep their current behaviour, only new ones rotate by default"*. Defaulting to 60 here would plan `0 → 60` on every managed configuration that doesn't set the attribute, silently enabling rotation of PRKs and recovery passwords on the next apply.
- A **static** recovery password forbids a rotation after reveal — the serializer rejects a non-zero `reveal_rotation_delay` there. A 60 default would break every static-password configuration outright.

Both attributes say so in their description, including that a configuration created outside Terraform defaults to 60.

Validation follows the API: `0`, or `5`–`1440`.

## Tests

The bare steps assert the `0` default, the full steps set `120`. The recovery password static-password step asserts `0`, which is the case a non-zero default would have broken.

Full acceptance suite green against zaio: 528s, 76.7% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)