### PR TITLE
Bump goztl to v0.1.77

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
-	github.com/zentralopensource/goztl v0.1.76
+	github.com/zentralopensource/goztl v0.1.77
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/zclconf/go-cty v1.18.1 h1:yEGE8M4iIZlyKQURZNb2SnEyZlZHUcBCnx6KF81KuwM
 github.com/zclconf/go-cty v1.18.1/go.mod h1:qpnV6EDNgC1sns/AleL1fvatHw72j+S+nS+MJ+T2CSg=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
-github.com/zentralopensource/goztl v0.1.76 h1:jYwpG7HWknAnmeHyi58aCXxFkqD+JQdW7bE9sk1YuLA=
-github.com/zentralopensource/goztl v0.1.76/go.mod h1:v7QVp73QeJM1WRffCmxzMEd/2q1K33050U2aep+fYD0=
+github.com/zentralopensource/goztl v0.1.77 h1:yZQouidVe/Xx7Tdo8t5rL1OCniHJHT2z4HSEKX8ZaOY=
+github.com/zentralopensource/goztl v0.1.77/go.mod h1:v7QVp73QeJM1WRffCmxzMEd/2q1K33050U2aep+fYD0=
 go.abhg.dev/goldmark/frontmatter v0.2.0 h1:P8kPG0YkL12+aYk2yU3xHv4tcXzeVnN+gU0tJ5JnxRw=
 go.abhg.dev/goldmark/frontmatter v0.2.0/go.mod h1:XqrEkZuM57djk7zrlRUB02x8I5J0px76YjkOzhB4YlU=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
zentralopensource/zentral#1586 paginates eleven MDM list endpoints — ACME issuers, SCEP issuers, FileVault configurations, recovery password configurations, software update enforcements, OTA enrollments, blueprints, blueprint artifacts, locations, location assets and push certificates. zentralopensource/goztl#84 follows the pages for them, and [v0.1.77](https://github.com/zentralopensource/goztl/releases/tag/v0.1.77) is the release that carries it.

Without this bump, every data source that looks one of those resources up by name fails against a 2026.5 server — goztl decodes the list response into a bare slice and the server now returns the `{count, next, previous, results}` envelope.

No provider code changes: the provider never calls `List` directly, so following the pages is entirely absorbed by the client.

### Verified

`gofmt -s -l`, `go build`, `go vet`, `go test ./...` and `go generate ./...` (zero docs diff) all clean. The acceptance tests are running against the test environment as I open this — I'll follow up here if anything turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)