### PR TITLE
Use the common.go helpers instead of the open-coded conversions

### DIFF
--- a/internal/provider/jmespath_check.go
+++ b/internal/provider/jmespath_check.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -18,23 +17,13 @@ type jmespathCheck struct {
 }
 
 func jmespathCheckForState(j *goztl.JMESPathCheck) jmespathCheck {
-	platforms := make([]attr.Value, 0)
-	for _, pv := range j.Platforms {
-		platforms = append(platforms, types.StringValue(pv))
-	}
-
-	tagIDs := make([]attr.Value, 0)
-	for _, tv := range j.TagIDs {
-		tagIDs = append(tagIDs, types.Int64Value(int64(tv)))
-	}
-
 	return jmespathCheck{
 		ID:                 types.Int64Value(int64(j.ID)),
 		Name:               types.StringValue(j.Name),
 		Description:        types.StringValue(j.Description),
 		SourceName:         types.StringValue(j.SourceName),
-		Platforms:          types.SetValueMust(types.StringType, platforms),
-		TagIDs:             types.SetValueMust(types.Int64Type, tagIDs),
+		Platforms:          stringSetForState(j.Platforms),
+		TagIDs:             int64SetForState(j.TagIDs),
 		JMESPathExpression: types.StringValue(j.JMESPathExpression),
 		Version:            types.Int64Value(int64(j.Version)),
 	}

--- a/internal/provider/jmespath_check_resource.go
+++ b/internal/provider/jmespath_check_resource.go
@@ -118,22 +118,12 @@ func (r *JMESPathCheckResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	platforms := make([]string, 0)
-	for _, pv := range data.Platforms.Elements() { // nil if null or unknown → no iterations
-		platforms = append(platforms, pv.(types.String).ValueString())
-	}
-
-	tagIDs := make([]int, 0)
-	for _, tv := range data.TagIDs.Elements() { // nil if null or unknown → no iterations
-		tagIDs = append(tagIDs, int(tv.(types.Int64).ValueInt64()))
-	}
-
 	ztlReq := &goztl.JMESPathCheckCreateRequest{
 		Name:               data.Name.ValueString(),
 		Description:        data.Description.ValueString(), // default to "" if null or unknown
 		SourceName:         data.SourceName.ValueString(),
-		Platforms:          platforms,
-		TagIDs:             tagIDs,
+		Platforms:          stringListWithStateSet(data.Platforms),
+		TagIDs:             intListWithState(data.TagIDs),
 		JMESPathExpression: data.JMESPathExpression.ValueString(),
 	}
 	ztlJC, _, err := r.client.JMESPathChecks.Create(ctx, ztlReq)
@@ -186,22 +176,12 @@ func (r *JMESPathCheckResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	platforms := make([]string, 0)
-	for _, pv := range data.Platforms.Elements() { // nil if null or unknown → no iterations
-		platforms = append(platforms, pv.(types.String).ValueString())
-	}
-
-	tagIDs := make([]int, 0)
-	for _, tv := range data.TagIDs.Elements() { // nil if null or unknown → no iterations
-		tagIDs = append(tagIDs, int(tv.(types.Int64).ValueInt64()))
-	}
-
 	ztlReq := &goztl.JMESPathCheckUpdateRequest{
 		Name:               data.Name.ValueString(),
 		Description:        data.Description.ValueString(), // default to "" if null or unknown
 		SourceName:         data.SourceName.ValueString(),
-		Platforms:          platforms,
-		TagIDs:             tagIDs,
+		Platforms:          stringListWithStateSet(data.Platforms),
+		TagIDs:             intListWithState(data.TagIDs),
 		JMESPathExpression: data.JMESPathExpression.ValueString(),
 	}
 	ztlJC, _, err := r.client.JMESPathChecks.Update(ctx, int(data.ID.ValueInt64()), ztlReq)

--- a/internal/provider/mdm_artifact.go
+++ b/internal/provider/mdm_artifact.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -20,50 +19,30 @@ type mdmArtifact struct {
 }
 
 func mdmArtifactForState(ma *goztl.MDMArtifact) mdmArtifact {
-	platforms := make([]attr.Value, 0)
-	for _, p := range ma.Platforms {
-		platforms = append(platforms, types.StringValue(p))
-	}
-
-	requires := make([]attr.Value, 0)
-	for _, raID := range ma.Requires {
-		requires = append(requires, types.StringValue(raID))
-	}
-
 	return mdmArtifact{
 		ID:                          types.StringValue(ma.ID),
 		Name:                        types.StringValue(ma.Name),
 		Type:                        types.StringValue(ma.Type),
 		Channel:                     types.StringValue(ma.Channel),
-		Platforms:                   types.SetValueMust(types.StringType, platforms),
+		Platforms:                   stringSetForState(ma.Platforms),
 		InstallDuringSetupAssistant: types.BoolValue(ma.InstallDuringSetupAssistant),
 		AutoUpdate:                  types.BoolValue(ma.AutoUpdate),
 		ReinstallInterval:           types.Int64Value(int64(ma.ReinstallInterval)),
 		ReinstallOnOSUpdate:         types.StringValue(ma.ReinstallOnOSUpdate),
-		Requires:                    types.SetValueMust(types.StringType, requires),
+		Requires:                    stringSetForState(ma.Requires),
 	}
 }
 
 func mdmArtifactRequestWithState(data mdmArtifact) *goztl.MDMArtifactRequest {
-	platforms := make([]string, 0)
-	for _, p := range data.Platforms.Elements() { // nil if null or unknown → no iterations
-		platforms = append(platforms, p.(types.String).ValueString())
-	}
-
-	requires := make([]string, 0)
-	for _, raID := range data.Requires.Elements() { // nil if null or unknown → no iterations
-		requires = append(requires, raID.(types.String).ValueString())
-	}
-
 	return &goztl.MDMArtifactRequest{
 		Name:                        data.Name.ValueString(),
 		Type:                        data.Type.ValueString(),
 		Channel:                     data.Channel.ValueString(),
-		Platforms:                   platforms,
+		Platforms:                   stringListWithStateSet(data.Platforms),
 		InstallDuringSetupAssistant: data.InstallDuringSetupAssistant.ValueBool(),
 		AutoUpdate:                  data.AutoUpdate.ValueBool(),
 		ReinstallInterval:           int(data.ReinstallInterval.ValueInt64()),
 		ReinstallOnOSUpdate:         data.ReinstallOnOSUpdate.ValueString(),
-		Requires:                    requires,
+		Requires:                    stringListWithStateSet(data.Requires),
 	}
 }

--- a/internal/provider/mdm_blueprint_artifact.go
+++ b/internal/provider/mdm_blueprint_artifact.go
@@ -29,11 +29,6 @@ type mdmBlueprintArtifact struct {
 }
 
 func mdmBlueprintArtifactForState(mba *goztl.MDMBlueprintArtifact) mdmBlueprintArtifact {
-	exTagIDs := make([]attr.Value, 0)
-	for _, exTagID := range mba.ExcludedTagIDs {
-		exTagIDs = append(exTagIDs, types.Int64Value(int64(exTagID)))
-	}
-
 	tagShards := make([]attr.Value, 0)
 	for _, tagShard := range mba.TagShards {
 		tagShards = append(
@@ -66,17 +61,12 @@ func mdmBlueprintArtifactForState(mba *goztl.MDMBlueprintArtifact) mdmBlueprintA
 		TVOSMinVersion:   types.StringValue(mba.TVOSMinVersion),
 		DefaultShard:     types.Int64Value(int64(mba.DefaultShard)),
 		ShardModulo:      types.Int64Value(int64(mba.ShardModulo)),
-		ExcludedTagIDs:   types.SetValueMust(types.Int64Type, exTagIDs),
+		ExcludedTagIDs:   int64SetForState(mba.ExcludedTagIDs),
 		TagShards:        types.SetValueMust(types.ObjectType{AttrTypes: tagShardAttrTypes}, tagShards),
 	}
 }
 
 func mdmBlueprintArtifactRequestWithState(data mdmBlueprintArtifact) *goztl.MDMBlueprintArtifactRequest {
-	exTagIDs := make([]int, 0)
-	for _, exTagID := range data.ExcludedTagIDs.Elements() { // nil if null or unknown → no iterations
-		exTagIDs = append(exTagIDs, int(exTagID.(types.Int64).ValueInt64()))
-	}
-
 	tagShards := make([]goztl.TagShard, 0)
 	for _, tagShard := range data.TagShards.Elements() { // nil if null or unknown → no iterations
 		tagShardMap := tagShard.(types.Object).Attributes()
@@ -108,7 +98,7 @@ func mdmBlueprintArtifactRequestWithState(data mdmBlueprintArtifact) *goztl.MDMB
 		TVOSMinVersion:   data.TVOSMinVersion.ValueString(),
 		DefaultShard:     int(data.DefaultShard.ValueInt64()),
 		ShardModulo:      int(data.ShardModulo.ValueInt64()),
-		ExcludedTagIDs:   exTagIDs,
+		ExcludedTagIDs:   intListWithState(data.ExcludedTagIDs),
 		TagShards:        tagShards,
 	}
 }

--- a/internal/provider/mdm_push_certificate.go
+++ b/internal/provider/mdm_push_certificate.go
@@ -14,32 +14,11 @@ type mdmPushCertificate struct {
 }
 
 func mdmPushCertificateForState(mpc *goztl.MDMPushCertificate) mdmPushCertificate {
-	var provisioningUID types.String
-	if mpc.ProvisioningUID != nil {
-		provisioningUID = types.StringValue(*mpc.ProvisioningUID)
-	} else {
-		provisioningUID = types.StringNull()
-	}
-
-	var topic types.String
-	if mpc.Topic != nil {
-		topic = types.StringValue(*mpc.Topic)
-	} else {
-		topic = types.StringNull()
-	}
-
-	var certificate types.String
-	if mpc.Certificate != nil {
-		certificate = types.StringValue(*mpc.Certificate)
-	} else {
-		certificate = types.StringNull()
-	}
-
 	return mdmPushCertificate{
 		ID:              types.Int64Value(int64(mpc.ID)),
-		ProvisioningUID: provisioningUID,
+		ProvisioningUID: optionalStringForState(mpc.ProvisioningUID),
 		Name:            types.StringValue(mpc.Name),
-		Topic:           topic,
-		Certificate:     certificate,
+		Topic:           optionalStringForState(mpc.Topic),
+		Certificate:     optionalStringForState(mpc.Certificate),
 	}
 }

--- a/internal/provider/mdm_recovery_password_config.go
+++ b/internal/provider/mdm_recovery_password_config.go
@@ -16,18 +16,11 @@ type mdmRecoveryPasswordConfig struct {
 }
 
 func mdmRecoveryPasswordConfigForState(mrpc *goztl.MDMRecoveryPasswordConfig) mdmRecoveryPasswordConfig {
-	var staticPassword types.String
-	if mrpc.StaticPassword != nil {
-		staticPassword = types.StringValue(*mrpc.StaticPassword)
-	} else {
-		staticPassword = types.StringNull()
-	}
-
 	return mdmRecoveryPasswordConfig{
 		ID:                     types.Int64Value(int64(mrpc.ID)),
 		Name:                   types.StringValue(mrpc.Name),
 		DynamicPassword:        types.BoolValue(mrpc.DynamicPassword),
-		StaticPassword:         staticPassword,
+		StaticPassword:         optionalStringForState(mrpc.StaticPassword),
 		RotationIntervalDays:   types.Int64Value(int64(mrpc.RotationIntervalDays)),
 		RevealRotationDelay:    types.Int64Value(int64(mrpc.RevealRotationDelay)),
 		RotateFirmwarePassword: types.BoolValue(mrpc.RotateFirmwarePassword),
@@ -35,15 +28,10 @@ func mdmRecoveryPasswordConfigForState(mrpc *goztl.MDMRecoveryPasswordConfig) md
 }
 
 func mdmRecoveryPasswordConfigRequestWithState(data mdmRecoveryPasswordConfig) *goztl.MDMRecoveryPasswordConfigRequest {
-	var staticPassword *string
-	if !data.StaticPassword.IsNull() {
-		staticPassword = goztl.String(data.StaticPassword.ValueString())
-	}
-
 	return &goztl.MDMRecoveryPasswordConfigRequest{
 		Name:                   data.Name.ValueString(),
 		DynamicPassword:        data.DynamicPassword.ValueBool(),
-		StaticPassword:         staticPassword,
+		StaticPassword:         optionalStringWithState(data.StaticPassword),
 		RotationIntervalDays:   int(data.RotationIntervalDays.ValueInt64()),
 		RevealRotationDelay:    int(data.RevealRotationDelay.ValueInt64()),
 		RotateFirmwarePassword: data.RotateFirmwarePassword.ValueBool(),

--- a/internal/provider/mdm_software_update_enforcement.go
+++ b/internal/provider/mdm_software_update_enforcement.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -21,68 +20,22 @@ type mdmSoftwareUpdateEnforcement struct {
 }
 
 func mdmSoftwareUpdateEnforcementForState(msue *goztl.MDMSoftwareUpdateEnforcement) mdmSoftwareUpdateEnforcement {
-	platforms := make([]attr.Value, 0)
-	for _, platform := range msue.Platforms {
-		platforms = append(platforms, types.StringValue(platform))
-	}
-
-	tagIDs := make([]attr.Value, 0)
-	for _, tagID := range msue.TagIDs {
-		tagIDs = append(tagIDs, types.Int64Value(int64(tagID)))
-	}
-
-	var ldt types.String
-	if msue.LocalDateTime != nil {
-		ldt = types.StringValue(*msue.LocalDateTime)
-	} else {
-		ldt = types.StringNull()
-	}
-
-	var dd types.Int64
-	if msue.DelayDays != nil {
-		dd = types.Int64Value(int64(*msue.DelayDays))
-	} else {
-		dd = types.Int64Null()
-	}
-
-	var lt types.String
-	if msue.LocalTime != nil {
-		lt = types.StringValue(*msue.LocalTime)
-	} else {
-		lt = types.StringNull()
-	}
-
 	return mdmSoftwareUpdateEnforcement{
 		ID:            types.Int64Value(int64(msue.ID)),
 		Name:          types.StringValue(msue.Name),
 		DetailsURL:    types.StringValue(msue.DetailsURL),
-		Platforms:     types.SetValueMust(types.StringType, platforms),
-		TagIDs:        types.SetValueMust(types.Int64Type, tagIDs),
+		Platforms:     stringSetForState(msue.Platforms),
+		TagIDs:        int64SetForState(msue.TagIDs),
 		OSVersion:     types.StringValue(msue.OSVersion),
 		BuildVersion:  types.StringValue(msue.BuildVersion),
-		LocalDateTime: ldt,
+		LocalDateTime: optionalStringForState(msue.LocalDateTime),
 		MaxOSVersion:  types.StringValue(msue.MaxOSVersion),
-		DelayDays:     dd,
-		LocalTime:     lt,
+		DelayDays:     optionalInt64ForState(msue.DelayDays),
+		LocalTime:     optionalStringForState(msue.LocalTime),
 	}
 }
 
 func mdmSoftwareUpdateEnforcementRequestWithState(data mdmSoftwareUpdateEnforcement) *goztl.MDMSoftwareUpdateEnforcementRequest {
-	platforms := make([]string, 0)
-	for _, platform := range data.Platforms.Elements() { // nil if null or unknown → no iterations
-		platforms = append(platforms, platform.(types.String).ValueString())
-	}
-
-	tagIDs := make([]int, 0)
-	for _, tagID := range data.TagIDs.Elements() { // nil if null or unknown → no iterations
-		tagIDs = append(tagIDs, int(tagID.(types.Int64).ValueInt64()))
-	}
-
-	var ldt *string
-	if !data.LocalDateTime.IsNull() {
-		ldt = goztl.String(data.LocalDateTime.ValueString())
-	}
-
 	var dd *int
 	if !data.DelayDays.IsUnknown() {
 		if !data.DelayDays.IsNull() {
@@ -104,11 +57,11 @@ func mdmSoftwareUpdateEnforcementRequestWithState(data mdmSoftwareUpdateEnforcem
 	return &goztl.MDMSoftwareUpdateEnforcementRequest{
 		Name:          data.Name.ValueString(),
 		DetailsURL:    data.DetailsURL.ValueString(),
-		Platforms:     platforms,
-		TagIDs:        tagIDs,
+		Platforms:     stringListWithStateSet(data.Platforms),
+		TagIDs:        intListWithState(data.TagIDs),
 		OSVersion:     data.OSVersion.ValueString(),
 		BuildVersion:  data.BuildVersion.ValueString(),
-		LocalDateTime: ldt,
+		LocalDateTime: optionalStringWithState(data.LocalDateTime),
 		MaxOSVersion:  data.MaxOSVersion.ValueString(),
 		DelayDays:     dd,
 		LocalTime:     lt,

--- a/internal/provider/monolith_enrollment.go
+++ b/internal/provider/monolith_enrollment.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -23,28 +22,6 @@ type monolithEnrollment struct {
 
 func monolithEnrollmentForState(me *goztl.MonolithEnrollment) monolithEnrollment {
 
-	tagIDs := make([]attr.Value, 0)
-	for _, tagID := range me.Secret.TagIDs {
-		tagIDs = append(tagIDs, types.Int64Value(int64(tagID)))
-	}
-
-	serialNumbers := make([]attr.Value, 0)
-	for _, serialNumber := range me.Secret.SerialNumbers {
-		serialNumbers = append(serialNumbers, types.StringValue(serialNumber))
-	}
-
-	udids := make([]attr.Value, 0)
-	for _, udid := range me.Secret.UDIDs {
-		udids = append(udids, types.StringValue(udid))
-	}
-
-	var quota types.Int64
-	if me.Secret.Quota != nil {
-		quota = types.Int64Value(int64(*me.Secret.Quota))
-	} else {
-		quota = types.Int64Null()
-	}
-
 	return monolithEnrollment{
 		ID:               types.Int64Value(int64(me.ID)),
 		ManifestID:       types.Int64Value(int64(me.ManifestID)),
@@ -54,42 +31,22 @@ func monolithEnrollmentForState(me *goztl.MonolithEnrollment) monolithEnrollment
 		// enrollment secret
 		Secret:             types.StringValue(me.Secret.Secret),
 		MetaBusinessUnitID: types.Int64Value(int64(me.Secret.MetaBusinessUnitID)),
-		TagIDs:             types.SetValueMust(types.Int64Type, tagIDs),
-		SerialNumbers:      types.SetValueMust(types.StringType, serialNumbers),
-		UDIDs:              types.SetValueMust(types.StringType, udids),
-		Quota:              quota,
+		TagIDs:             int64SetForState(me.Secret.TagIDs),
+		SerialNumbers:      stringSetForState(me.Secret.SerialNumbers),
+		UDIDs:              stringSetForState(me.Secret.UDIDs),
+		Quota:              optionalInt64ForState(me.Secret.Quota),
 	}
 }
 
 func monolithEnrollmentRequestWithState(data monolithEnrollment) *goztl.MonolithEnrollmentRequest {
-	tagIDs := make([]int, 0)
-	for _, tagID := range data.TagIDs.Elements() { // nil if null or unknown → no iterations
-		tagIDs = append(tagIDs, int(tagID.(types.Int64).ValueInt64()))
-	}
-
-	serialNumbers := make([]string, 0)
-	for _, serialNumber := range data.SerialNumbers.Elements() { // nil if null or unknown → no iterations
-		serialNumbers = append(serialNumbers, serialNumber.(types.String).ValueString())
-	}
-
-	udids := make([]string, 0)
-	for _, udid := range data.UDIDs.Elements() { // nil if null or unknown → no iterations
-		udids = append(udids, udid.(types.String).ValueString())
-	}
-
-	monolithEnrollmentRequest := &goztl.MonolithEnrollmentRequest{
+	return &goztl.MonolithEnrollmentRequest{
 		ManifestID: int(data.ManifestID.ValueInt64()),
 		Secret: goztl.EnrollmentSecretRequest{
 			MetaBusinessUnitID: int(data.MetaBusinessUnitID.ValueInt64()),
-			TagIDs:             tagIDs,
-			SerialNumbers:      serialNumbers,
-			UDIDs:              udids,
+			TagIDs:             intListWithState(data.TagIDs),
+			SerialNumbers:      stringListWithStateSet(data.SerialNumbers),
+			UDIDs:              stringListWithStateSet(data.UDIDs),
+			Quota:              optionalIntWithState(data.Quota),
 		},
 	}
-
-	if !data.Quota.IsNull() {
-		monolithEnrollmentRequest.Secret.Quota = goztl.Int(int(data.Quota.ValueInt64()))
-	}
-
-	return monolithEnrollmentRequest
 }

--- a/internal/provider/monolith_manifest_catalog.go
+++ b/internal/provider/monolith_manifest_catalog.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -14,28 +13,18 @@ type monolithManifestCatalog struct {
 }
 
 func monolithManifestCatalogForState(mmc *goztl.MonolithManifestCatalog) monolithManifestCatalog {
-	tagIDs := make([]attr.Value, 0)
-	for _, tagID := range mmc.TagIDs {
-		tagIDs = append(tagIDs, types.Int64Value(int64(tagID)))
-	}
-
 	return monolithManifestCatalog{
 		ID:         types.Int64Value(int64(mmc.ID)),
 		ManifestID: types.Int64Value(int64(mmc.ManifestID)),
 		CatalogID:  types.Int64Value(int64(mmc.CatalogID)),
-		TagIDs:     types.SetValueMust(types.Int64Type, tagIDs),
+		TagIDs:     int64SetForState(mmc.TagIDs),
 	}
 }
 
 func monolithManifestCatalogRequestWithState(data monolithManifestCatalog) *goztl.MonolithManifestCatalogRequest {
-	tagIDs := make([]int, 0)
-	for _, tagID := range data.TagIDs.Elements() { // nil if null or unknown → no iterations
-		tagIDs = append(tagIDs, int(tagID.(types.Int64).ValueInt64()))
-	}
-
 	return &goztl.MonolithManifestCatalogRequest{
 		ManifestID: int(data.ManifestID.ValueInt64()),
 		CatalogID:  int(data.CatalogID.ValueInt64()),
-		TagIDs:     tagIDs,
+		TagIDs:     intListWithState(data.TagIDs),
 	}
 }

--- a/internal/provider/monolith_manifest_enrollment_package.go
+++ b/internal/provider/monolith_manifest_enrollment_package.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -16,31 +15,21 @@ type monolithManifestEnrollmentPackage struct {
 }
 
 func monolithManifestEnrollmentPackageForState(mmep *goztl.MonolithManifestEnrollmentPackage) monolithManifestEnrollmentPackage {
-	tagIDs := make([]attr.Value, 0)
-	for _, tagID := range mmep.TagIDs {
-		tagIDs = append(tagIDs, types.Int64Value(int64(tagID)))
-	}
-
 	return monolithManifestEnrollmentPackage{
 		ID:           types.Int64Value(int64(mmep.ID)),
 		ManifestID:   types.Int64Value(int64(mmep.ManifestID)),
 		Builder:      types.StringValue(mmep.Builder),
 		EnrollmentID: types.Int64Value(int64(mmep.EnrollmentID)),
 		Version:      types.Int64Value(int64(mmep.Version)),
-		TagIDs:       types.SetValueMust(types.Int64Type, tagIDs),
+		TagIDs:       int64SetForState(mmep.TagIDs),
 	}
 }
 
 func monolithManifestEnrollmentPackageRequestWithState(data monolithManifestEnrollmentPackage) *goztl.MonolithManifestEnrollmentPackageRequest {
-	tagIDs := make([]int, 0)
-	for _, tagID := range data.TagIDs.Elements() { // nil if null or unknown → no iterations
-		tagIDs = append(tagIDs, int(tagID.(types.Int64).ValueInt64()))
-	}
-
 	return &goztl.MonolithManifestEnrollmentPackageRequest{
 		ManifestID:   int(data.ManifestID.ValueInt64()),
 		Builder:      data.Builder.ValueString(),
 		EnrollmentID: int(data.EnrollmentID.ValueInt64()),
-		TagIDs:       tagIDs,
+		TagIDs:       intListWithState(data.TagIDs),
 	}
 }

--- a/internal/provider/monolith_manifest_sub_manifest.go
+++ b/internal/provider/monolith_manifest_sub_manifest.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -14,28 +13,18 @@ type monolithManifestSubManifest struct {
 }
 
 func monolithManifestSubManifestForState(mmsm *goztl.MonolithManifestSubManifest) monolithManifestSubManifest {
-	tagIDs := make([]attr.Value, 0)
-	for _, tagID := range mmsm.TagIDs {
-		tagIDs = append(tagIDs, types.Int64Value(int64(tagID)))
-	}
-
 	return monolithManifestSubManifest{
 		ID:            types.Int64Value(int64(mmsm.ID)),
 		ManifestID:    types.Int64Value(int64(mmsm.ManifestID)),
 		SubManifestID: types.Int64Value(int64(mmsm.SubManifestID)),
-		TagIDs:        types.SetValueMust(types.Int64Type, tagIDs),
+		TagIDs:        int64SetForState(mmsm.TagIDs),
 	}
 }
 
 func monolithManifestSubManifestRequestWithState(data monolithManifestSubManifest) *goztl.MonolithManifestSubManifestRequest {
-	tagIDs := make([]int, 0)
-	for _, tagID := range data.TagIDs.Elements() { // nil if null or unknown → no iterations
-		tagIDs = append(tagIDs, int(tagID.(types.Int64).ValueInt64()))
-	}
-
 	return &goztl.MonolithManifestSubManifestRequest{
 		ManifestID:    int(data.ManifestID.ValueInt64()),
 		SubManifestID: int(data.SubManifestID.ValueInt64()),
-		TagIDs:        tagIDs,
+		TagIDs:        intListWithState(data.TagIDs),
 	}
 }

--- a/internal/provider/monolith_repository.go
+++ b/internal/provider/monolith_repository.go
@@ -45,13 +45,6 @@ var s3AttrTypes = map[string]attr.Type{
 }
 
 func monolithRepositoryForState(mr *goztl.MonolithRepository) monolithRepository {
-	var mbu types.Int64
-	if mr.MetaBusinessUnitID != nil {
-		mbu = types.Int64Value(int64(*mr.MetaBusinessUnitID))
-	} else {
-		mbu = types.Int64Null()
-	}
-
 	var az types.Object
 	if mr.Azure != nil {
 		az = types.ObjectValueMust(
@@ -94,7 +87,7 @@ func monolithRepositoryForState(mr *goztl.MonolithRepository) monolithRepository
 	return monolithRepository{
 		ID:                 types.Int64Value(int64(mr.ID)),
 		Name:               types.StringValue(mr.Name),
-		MetaBusinessUnitID: mbu,
+		MetaBusinessUnitID: optionalInt64ForState(mr.MetaBusinessUnitID),
 		Backend:            types.StringValue(mr.Backend),
 		Azure:              az,
 		S3:                 s3,
@@ -102,14 +95,9 @@ func monolithRepositoryForState(mr *goztl.MonolithRepository) monolithRepository
 }
 
 func monolithRepositoryRequestWithState(data monolithRepository) *goztl.MonolithRepositoryRequest {
-	var mbu *int
-	if !data.MetaBusinessUnitID.IsNull() {
-		mbu = goztl.Int(int(data.MetaBusinessUnitID.ValueInt64()))
-	}
-
 	req := &goztl.MonolithRepositoryRequest{
 		Name:               data.Name.ValueString(),
-		MetaBusinessUnitID: mbu,
+		MetaBusinessUnitID: optionalIntWithState(data.MetaBusinessUnitID),
 		Backend:            data.Backend.ValueString(),
 	}
 

--- a/internal/provider/monolith_sub_manifest.go
+++ b/internal/provider/monolith_sub_manifest.go
@@ -13,30 +13,18 @@ type monolithSubManifest struct {
 }
 
 func monolithSubManifestForState(msm *goztl.MonolithSubManifest) monolithSubManifest {
-	var mbu types.Int64
-	if msm.MetaBusinessUnitID != nil {
-		mbu = types.Int64Value(int64(*msm.MetaBusinessUnitID))
-	} else {
-		mbu = types.Int64Null()
-	}
-
 	return monolithSubManifest{
 		ID:                 types.Int64Value(int64(msm.ID)),
 		Name:               types.StringValue(msm.Name),
 		Description:        types.StringValue(msm.Description),
-		MetaBusinessUnitID: mbu,
+		MetaBusinessUnitID: optionalInt64ForState(msm.MetaBusinessUnitID),
 	}
 }
 
 func monolithSubManifestRequestWithState(data monolithSubManifest) *goztl.MonolithSubManifestRequest {
-	var mbu *int
-	if !data.MetaBusinessUnitID.IsNull() {
-		mbu = goztl.Int(int(data.MetaBusinessUnitID.ValueInt64()))
-	}
-
 	return &goztl.MonolithSubManifestRequest{
 		Name:               data.Name.ValueString(),
 		Description:        data.Description.ValueString(),
-		MetaBusinessUnitID: mbu,
+		MetaBusinessUnitID: optionalIntWithState(data.MetaBusinessUnitID),
 	}
 }

--- a/internal/provider/monolith_sub_manifest_pkg_info.go
+++ b/internal/provider/monolith_sub_manifest_pkg_info.go
@@ -25,18 +25,6 @@ var tagShardAttrTypes = map[string]attr.Type{
 }
 
 func monolithSubManifestPkgInfoForState(msmpi *goztl.MonolithSubManifestPkgInfo) monolithSubManifestPkgInfo {
-	var cID types.Int64
-	if msmpi.ConditionID != nil {
-		cID = types.Int64Value(int64(*msmpi.ConditionID))
-	} else {
-		cID = types.Int64Null()
-	}
-
-	exTagIDs := make([]attr.Value, 0)
-	for _, exTagID := range msmpi.ExcludedTagIDs {
-		exTagIDs = append(exTagIDs, types.Int64Value(int64(exTagID)))
-	}
-
 	tagShards := make([]attr.Value, 0)
 	for _, tagShard := range msmpi.TagShards {
 		tagShards = append(
@@ -57,25 +45,15 @@ func monolithSubManifestPkgInfoForState(msmpi *goztl.MonolithSubManifestPkgInfo)
 		Key:            types.StringValue(msmpi.Key),
 		PkgInfoName:    types.StringValue(msmpi.PkgInfoName),
 		FeaturedItem:   types.BoolValue(msmpi.FeaturedItem),
-		ConditionID:    cID,
+		ConditionID:    optionalInt64ForState(msmpi.ConditionID),
 		ShardModulo:    types.Int64Value(int64(msmpi.ShardModulo)),
 		DefaultShard:   types.Int64Value(int64(msmpi.DefaultShard)),
-		ExcludedTagIDs: types.SetValueMust(types.Int64Type, exTagIDs),
+		ExcludedTagIDs: int64SetForState(msmpi.ExcludedTagIDs),
 		TagShards:      types.SetValueMust(types.ObjectType{AttrTypes: tagShardAttrTypes}, tagShards),
 	}
 }
 
 func monolithSubManifestPkgInfoRequestWithState(data monolithSubManifestPkgInfo) *goztl.MonolithSubManifestPkgInfoRequest {
-	var cID *int
-	if !data.ConditionID.IsNull() {
-		cID = goztl.Int(int(data.ConditionID.ValueInt64()))
-	}
-
-	exTagIDs := make([]int, 0)
-	for _, exTagID := range data.ExcludedTagIDs.Elements() { // nil if null or unknown → no iterations
-		exTagIDs = append(exTagIDs, int(exTagID.(types.Int64).ValueInt64()))
-	}
-
 	tagShards := make([]goztl.TagShard, 0)
 	for _, tagShard := range data.TagShards.Elements() { // nil if null or unknown → no iterations
 		tagShardMap := tagShard.(types.Object).Attributes()
@@ -95,10 +73,10 @@ func monolithSubManifestPkgInfoRequestWithState(data monolithSubManifestPkgInfo)
 		Key:            data.Key.ValueString(),
 		PkgInfoName:    data.PkgInfoName.ValueString(),
 		FeaturedItem:   data.FeaturedItem.ValueBool(),
-		ConditionID:    cID,
+		ConditionID:    optionalIntWithState(data.ConditionID),
 		ShardModulo:    int(data.ShardModulo.ValueInt64()),
 		DefaultShard:   int(data.DefaultShard.ValueInt64()),
-		ExcludedTagIDs: exTagIDs,
+		ExcludedTagIDs: intListWithState(data.ExcludedTagIDs),
 		TagShards:      tagShards,
 	}
 }

--- a/internal/provider/munki_configuration.go
+++ b/internal/provider/munki_configuration.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -22,29 +21,14 @@ type munkiConfiguration struct {
 }
 
 func munkiConfigurationForState(mc *goztl.MunkiConfiguration) munkiConfiguration {
-	pudss := make([]attr.Value, 0)
-	for _, puds := range mc.PrincipalUserDetectionSources {
-		pudss = append(pudss, types.StringValue(puds))
-	}
-
-	pudds := make([]attr.Value, 0)
-	for _, pudd := range mc.PrincipalUserDetectionDomains {
-		pudds = append(pudds, types.StringValue(pudd))
-	}
-
-	ccks := make([]attr.Value, 0)
-	for _, cck := range mc.CollectedConditionKeys {
-		ccks = append(ccks, types.StringValue(cck))
-	}
-
 	return munkiConfiguration{
 		ID:                              types.Int64Value(int64(mc.ID)),
 		Name:                            types.StringValue(mc.Name),
 		Description:                     types.StringValue(mc.Description),
 		InventoryAppsFullInfoShard:      types.Int64Value(int64(mc.InventoryAppsFullInfoShard)),
-		PrincipalUserDetectionSources:   types.ListValueMust(types.StringType, pudss),
-		PrincipalUserDetectionDomains:   types.SetValueMust(types.StringType, pudds),
-		CollectedConditionKeys:          types.SetValueMust(types.StringType, ccks),
+		PrincipalUserDetectionSources:   stringListForState(mc.PrincipalUserDetectionSources),
+		PrincipalUserDetectionDomains:   stringSetForState(mc.PrincipalUserDetectionDomains),
+		CollectedConditionKeys:          stringSetForState(mc.CollectedConditionKeys),
 		ManagedInstallsSyncIntervalDays: types.Int64Value(int64(mc.ManagedInstallsSyncIntervalDays)),
 		ScriptChecksRunIntervalSeconds:  types.Int64Value(int64(mc.ScriptChecksRunIntervalSeconds)),
 		AutoReinstallIncidents:          types.BoolValue(mc.AutoReinstallIncidents),
@@ -54,28 +38,13 @@ func munkiConfigurationForState(mc *goztl.MunkiConfiguration) munkiConfiguration
 }
 
 func munkiConfigurationRequestWithState(data munkiConfiguration) *goztl.MunkiConfigurationRequest {
-	pudss := make([]string, 0)
-	for _, puds := range data.PrincipalUserDetectionSources.Elements() {
-		pudss = append(pudss, puds.(types.String).ValueString())
-	}
-
-	pudds := make([]string, 0)
-	for _, pudd := range data.PrincipalUserDetectionDomains.Elements() {
-		pudds = append(pudds, pudd.(types.String).ValueString())
-	}
-
-	ccks := make([]string, 0)
-	for _, cck := range data.CollectedConditionKeys.Elements() {
-		ccks = append(ccks, cck.(types.String).ValueString())
-	}
-
 	return &goztl.MunkiConfigurationRequest{
 		Name:                            data.Name.ValueString(),
 		Description:                     data.Description.ValueString(),
 		InventoryAppsFullInfoShard:      int(data.InventoryAppsFullInfoShard.ValueInt64()),
-		PrincipalUserDetectionSources:   pudss,
-		PrincipalUserDetectionDomains:   pudds,
-		CollectedConditionKeys:          ccks,
+		PrincipalUserDetectionSources:   stringListWithStateList(data.PrincipalUserDetectionSources),
+		PrincipalUserDetectionDomains:   stringListWithStateSet(data.PrincipalUserDetectionDomains),
+		CollectedConditionKeys:          stringListWithStateSet(data.CollectedConditionKeys),
 		ManagedInstallsSyncIntervalDays: int(data.ManagedInstallsSyncIntervalDays.ValueInt64()),
 		ScriptChecksRunIntervalSeconds:  int(data.ScriptChecksRunIntervalSeconds.ValueInt64()),
 		AutoReinstallIncidents:          data.AutoReinstallIncidents.ValueBool(),

--- a/internal/provider/munki_enrollment.go
+++ b/internal/provider/munki_enrollment.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -22,28 +21,6 @@ type munkiEnrollment struct {
 
 func munkiEnrollmentForState(me *goztl.MunkiEnrollment) munkiEnrollment {
 
-	tagIDs := make([]attr.Value, 0)
-	for _, tagID := range me.Secret.TagIDs {
-		tagIDs = append(tagIDs, types.Int64Value(int64(tagID)))
-	}
-
-	serialNumbers := make([]attr.Value, 0)
-	for _, serialNumber := range me.Secret.SerialNumbers {
-		serialNumbers = append(serialNumbers, types.StringValue(serialNumber))
-	}
-
-	udids := make([]attr.Value, 0)
-	for _, udid := range me.Secret.UDIDs {
-		udids = append(udids, types.StringValue(udid))
-	}
-
-	var quota types.Int64
-	if me.Secret.Quota != nil {
-		quota = types.Int64Value(int64(*me.Secret.Quota))
-	} else {
-		quota = types.Int64Null()
-	}
-
 	return munkiEnrollment{
 		ID:              types.Int64Value(int64(me.ID)),
 		ConfigurationID: types.Int64Value(int64(me.ConfigurationID)),
@@ -52,42 +29,22 @@ func munkiEnrollmentForState(me *goztl.MunkiEnrollment) munkiEnrollment {
 		// enrollment secret
 		Secret:             types.StringValue(me.Secret.Secret),
 		MetaBusinessUnitID: types.Int64Value(int64(me.Secret.MetaBusinessUnitID)),
-		TagIDs:             types.SetValueMust(types.Int64Type, tagIDs),
-		SerialNumbers:      types.SetValueMust(types.StringType, serialNumbers),
-		UDIDs:              types.SetValueMust(types.StringType, udids),
-		Quota:              quota,
+		TagIDs:             int64SetForState(me.Secret.TagIDs),
+		SerialNumbers:      stringSetForState(me.Secret.SerialNumbers),
+		UDIDs:              stringSetForState(me.Secret.UDIDs),
+		Quota:              optionalInt64ForState(me.Secret.Quota),
 	}
 }
 
 func munkiEnrollmentRequestWithState(data munkiEnrollment) *goztl.MunkiEnrollmentRequest {
-	tagIDs := make([]int, 0)
-	for _, tagID := range data.TagIDs.Elements() { // nil if null or unknown → no iterations
-		tagIDs = append(tagIDs, int(tagID.(types.Int64).ValueInt64()))
-	}
-
-	serialNumbers := make([]string, 0)
-	for _, serialNumber := range data.SerialNumbers.Elements() { // nil if null or unknown → no iterations
-		serialNumbers = append(serialNumbers, serialNumber.(types.String).ValueString())
-	}
-
-	udids := make([]string, 0)
-	for _, udid := range data.UDIDs.Elements() { // nil if null or unknown → no iterations
-		udids = append(udids, udid.(types.String).ValueString())
-	}
-
-	munkiEnrollmentRequest := &goztl.MunkiEnrollmentRequest{
+	return &goztl.MunkiEnrollmentRequest{
 		ConfigurationID: int(data.ConfigurationID.ValueInt64()),
 		Secret: goztl.EnrollmentSecretRequest{
 			MetaBusinessUnitID: int(data.MetaBusinessUnitID.ValueInt64()),
-			TagIDs:             tagIDs,
-			SerialNumbers:      serialNumbers,
-			UDIDs:              udids,
+			TagIDs:             intListWithState(data.TagIDs),
+			SerialNumbers:      stringListWithStateSet(data.SerialNumbers),
+			UDIDs:              stringListWithStateSet(data.UDIDs),
+			Quota:              optionalIntWithState(data.Quota),
 		},
 	}
-
-	if !data.Quota.IsNull() {
-		munkiEnrollmentRequest.Secret.Quota = goztl.Int(int(data.Quota.ValueInt64()))
-	}
-
-	return munkiEnrollmentRequest
 }

--- a/internal/provider/munki_script_check.go
+++ b/internal/provider/munki_script_check.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -23,16 +22,6 @@ type munkiScriptCheck struct {
 }
 
 func munkiScriptCheckForState(msc *goztl.MunkiScriptCheck) munkiScriptCheck {
-	tagIDs := make([]attr.Value, 0)
-	for _, tv := range msc.TagIDs {
-		tagIDs = append(tagIDs, types.Int64Value(int64(tv)))
-	}
-
-	excludedTagIDs := make([]attr.Value, 0)
-	for _, tv := range msc.ExcludedTagIDs {
-		excludedTagIDs = append(excludedTagIDs, types.Int64Value(int64(tv)))
-	}
-
 	return munkiScriptCheck{
 		ID:             types.Int64Value(int64(msc.ID)),
 		Name:           types.StringValue(msc.Name),
@@ -44,23 +33,13 @@ func munkiScriptCheckForState(msc *goztl.MunkiScriptCheck) munkiScriptCheck {
 		ArchARM64:      types.BoolValue(msc.ArchARM64),
 		MinOSVersion:   types.StringValue(msc.MinOSVersion),
 		MaxOSVersion:   types.StringValue(msc.MaxOSVersion),
-		TagIDs:         types.SetValueMust(types.Int64Type, tagIDs),
-		ExcludedTagIDs: types.SetValueMust(types.Int64Type, excludedTagIDs),
+		TagIDs:         int64SetForState(msc.TagIDs),
+		ExcludedTagIDs: int64SetForState(msc.ExcludedTagIDs),
 		Version:        types.Int64Value(int64(msc.Version)),
 	}
 }
 
 func munkiScriptCheckRequestWithState(data munkiScriptCheck) *goztl.MunkiScriptCheckRequest {
-	tagIDs := make([]int, 0)
-	for _, tagID := range data.TagIDs.Elements() { // nil if null or unknown → no iterations
-		tagIDs = append(tagIDs, int(tagID.(types.Int64).ValueInt64()))
-	}
-
-	excludedTagIDs := make([]int, 0)
-	for _, tagID := range data.ExcludedTagIDs.Elements() { // nil if null or unknown → no iterations
-		excludedTagIDs = append(excludedTagIDs, int(tagID.(types.Int64).ValueInt64()))
-	}
-
 	return &goztl.MunkiScriptCheckRequest{
 		Name:           data.Name.ValueString(),
 		Description:    data.Description.ValueString(),
@@ -71,7 +50,7 @@ func munkiScriptCheckRequestWithState(data munkiScriptCheck) *goztl.MunkiScriptC
 		ArchARM64:      data.ArchARM64.ValueBool(),
 		MinOSVersion:   data.MinOSVersion.ValueString(),
 		MaxOSVersion:   data.MaxOSVersion.ValueString(),
-		TagIDs:         tagIDs,
-		ExcludedTagIDs: excludedTagIDs,
+		TagIDs:         intListWithState(data.TagIDs),
+		ExcludedTagIDs: intListWithState(data.ExcludedTagIDs),
 	}
 }

--- a/internal/provider/osquery_atc.go
+++ b/internal/provider/osquery_atc.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -18,16 +17,6 @@ type osqueryATC struct {
 }
 
 func osqueryATCForState(oa *goztl.OsqueryATC) osqueryATC {
-	columns := make([]attr.Value, 0)
-	for _, column := range oa.Columns {
-		columns = append(columns, types.StringValue(column))
-	}
-
-	platforms := make([]attr.Value, 0)
-	for _, platform := range oa.Platforms {
-		platforms = append(platforms, types.StringValue(platform))
-	}
-
 	return osqueryATC{
 		ID:          types.Int64Value(int64(oa.ID)),
 		Name:        types.StringValue(oa.Name),
@@ -35,29 +24,19 @@ func osqueryATCForState(oa *goztl.OsqueryATC) osqueryATC {
 		TableName:   types.StringValue(oa.TableName),
 		Query:       types.StringValue(oa.Query),
 		Path:        types.StringValue(oa.Path),
-		Columns:     types.ListValueMust(types.StringType, columns),
-		Platforms:   types.SetValueMust(types.StringType, platforms),
+		Columns:     stringListForState(oa.Columns),
+		Platforms:   stringSetForState(oa.Platforms),
 	}
 }
 
 func osqueryATCRequestWithState(data osqueryATC) *goztl.OsqueryATCRequest {
-	columns := make([]string, 0)
-	for _, column := range data.Columns.Elements() { // nil if null or unknown → no iterations
-		columns = append(columns, column.(types.String).ValueString())
-	}
-
-	platforms := make([]string, 0)
-	for _, platform := range data.Platforms.Elements() { // nil if null or unknown → no iterations
-		platforms = append(platforms, platform.(types.String).ValueString())
-	}
-
 	return &goztl.OsqueryATCRequest{
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueString(),
 		TableName:   data.TableName.ValueString(),
 		Query:       data.Query.ValueString(),
 		Path:        data.Path.ValueString(),
-		Columns:     columns,
-		Platforms:   platforms,
+		Columns:     stringListWithStateList(data.Columns),
+		Platforms:   stringListWithStateSet(data.Platforms),
 	}
 }

--- a/internal/provider/osquery_configuration.go
+++ b/internal/provider/osquery_configuration.go
@@ -27,16 +27,6 @@ func osqueryConfigurationForState(oc *goztl.OsqueryConfiguration) osqueryConfigu
 		options[k] = types.StringValue(fmt.Sprintf("%v", v))
 	}
 
-	atcIDs := make([]attr.Value, 0)
-	for _, atcID := range oc.ATCIDs {
-		atcIDs = append(atcIDs, types.Int64Value(int64(atcID)))
-	}
-
-	fileCategoryIDs := make([]attr.Value, 0)
-	for _, fileCategoryID := range oc.FileCategoryIDs {
-		fileCategoryIDs = append(fileCategoryIDs, types.Int64Value(int64(fileCategoryID)))
-	}
-
 	return osqueryConfiguration{
 		ID:                types.Int64Value(int64(oc.ID)),
 		Name:              types.StringValue(oc.Name),
@@ -46,8 +36,8 @@ func osqueryConfigurationForState(oc *goztl.OsqueryConfiguration) osqueryConfigu
 		InventoryEC2:      types.BoolValue(oc.InventoryEC2),
 		InventoryInterval: types.Int64Value(int64(oc.InventoryInterval)),
 		Options:           types.MapValueMust(types.StringType, options),
-		ATCIDs:            types.SetValueMust(types.Int64Type, atcIDs),
-		FileCategoryIDs:   types.SetValueMust(types.Int64Type, fileCategoryIDs),
+		ATCIDs:            int64SetForState(oc.ATCIDs),
+		FileCategoryIDs:   int64SetForState(oc.FileCategoryIDs),
 	}
 }
 
@@ -55,16 +45,6 @@ func osqueryConfigurationRequestWithState(data osqueryConfiguration) *goztl.Osqu
 	options := make(map[string]interface{})
 	for k, v := range data.Options.Elements() {
 		options[k] = v.(types.String).ValueString()
-	}
-
-	atcIDs := make([]int, 0)
-	for _, atcID := range data.ATCIDs.Elements() { // nil if null or unknown → no iterations
-		atcIDs = append(atcIDs, int(atcID.(types.Int64).ValueInt64()))
-	}
-
-	fileCategoryIDs := make([]int, 0)
-	for _, fileCategoryID := range data.FileCategoryIDs.Elements() { // nil if null or unknown → no iterations
-		fileCategoryIDs = append(fileCategoryIDs, int(fileCategoryID.(types.Int64).ValueInt64()))
 	}
 
 	return &goztl.OsqueryConfigurationRequest{
@@ -75,7 +55,7 @@ func osqueryConfigurationRequestWithState(data osqueryConfiguration) *goztl.Osqu
 		InventoryEC2:      data.InventoryEC2.ValueBool(),
 		InventoryInterval: int(data.InventoryInterval.ValueInt64()),
 		Options:           options,
-		ATCIDs:            atcIDs,
-		FileCategoryIDs:   fileCategoryIDs,
+		ATCIDs:            intListWithState(data.ATCIDs),
+		FileCategoryIDs:   intListWithState(data.FileCategoryIDs),
 	}
 }

--- a/internal/provider/osquery_enrollment.go
+++ b/internal/provider/osquery_enrollment.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -25,28 +24,6 @@ type osqueryEnrollment struct {
 
 func osqueryEnrollmentForState(oe *goztl.OsqueryEnrollment) osqueryEnrollment {
 
-	tagIDs := make([]attr.Value, 0)
-	for _, tagID := range oe.Secret.TagIDs {
-		tagIDs = append(tagIDs, types.Int64Value(int64(tagID)))
-	}
-
-	serialNumbers := make([]attr.Value, 0)
-	for _, serialNumber := range oe.Secret.SerialNumbers {
-		serialNumbers = append(serialNumbers, types.StringValue(serialNumber))
-	}
-
-	udids := make([]attr.Value, 0)
-	for _, udid := range oe.Secret.UDIDs {
-		udids = append(udids, types.StringValue(udid))
-	}
-
-	var quota types.Int64
-	if oe.Secret.Quota != nil {
-		quota = types.Int64Value(int64(*oe.Secret.Quota))
-	} else {
-		quota = types.Int64Null()
-	}
-
 	return osqueryEnrollment{
 		ID:                  types.Int64Value(int64(oe.ID)),
 		ConfigurationID:     types.Int64Value(int64(oe.ConfigurationID)),
@@ -58,43 +35,23 @@ func osqueryEnrollmentForState(oe *goztl.OsqueryEnrollment) osqueryEnrollment {
 		// enrollment secret
 		Secret:             types.StringValue(oe.Secret.Secret),
 		MetaBusinessUnitID: types.Int64Value(int64(oe.Secret.MetaBusinessUnitID)),
-		TagIDs:             types.SetValueMust(types.Int64Type, tagIDs),
-		SerialNumbers:      types.SetValueMust(types.StringType, serialNumbers),
-		UDIDs:              types.SetValueMust(types.StringType, udids),
-		Quota:              quota,
+		TagIDs:             int64SetForState(oe.Secret.TagIDs),
+		SerialNumbers:      stringSetForState(oe.Secret.SerialNumbers),
+		UDIDs:              stringSetForState(oe.Secret.UDIDs),
+		Quota:              optionalInt64ForState(oe.Secret.Quota),
 	}
 }
 
 func osqueryEnrollmentRequestWithState(data osqueryEnrollment) *goztl.OsqueryEnrollmentRequest {
-	tagIDs := make([]int, 0)
-	for _, tagID := range data.TagIDs.Elements() { // nil if null or unknown → no iterations
-		tagIDs = append(tagIDs, int(tagID.(types.Int64).ValueInt64()))
-	}
-
-	serialNumbers := make([]string, 0)
-	for _, serialNumber := range data.SerialNumbers.Elements() { // nil if null or unknown → no iterations
-		serialNumbers = append(serialNumbers, serialNumber.(types.String).ValueString())
-	}
-
-	udids := make([]string, 0)
-	for _, udid := range data.UDIDs.Elements() { // nil if null or unknown → no iterations
-		udids = append(udids, udid.(types.String).ValueString())
-	}
-
-	osqueryEnrollmentRequest := &goztl.OsqueryEnrollmentRequest{
+	return &goztl.OsqueryEnrollmentRequest{
 		ConfigurationID: int(data.ConfigurationID.ValueInt64()),
 		OsqueryRelease:  data.OsqueryRelease.ValueString(),
 		Secret: goztl.EnrollmentSecretRequest{
 			MetaBusinessUnitID: int(data.MetaBusinessUnitID.ValueInt64()),
-			TagIDs:             tagIDs,
-			SerialNumbers:      serialNumbers,
-			UDIDs:              udids,
+			TagIDs:             intListWithState(data.TagIDs),
+			SerialNumbers:      stringListWithStateSet(data.SerialNumbers),
+			UDIDs:              stringListWithStateSet(data.UDIDs),
+			Quota:              optionalIntWithState(data.Quota),
 		},
 	}
-
-	if !data.Quota.IsNull() {
-		osqueryEnrollmentRequest.Secret.Quota = goztl.Int(int(data.Quota.ValueInt64()))
-	}
-
-	return osqueryEnrollmentRequest
 }

--- a/internal/provider/osquery_file_category.go
+++ b/internal/provider/osquery_file_category.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -17,54 +16,24 @@ type osqueryFileCategory struct {
 }
 
 func osqueryFileCategoryForState(ofc *goztl.OsqueryFileCategory) osqueryFileCategory {
-	filePaths := make([]attr.Value, 0)
-	for _, filePath := range ofc.FilePaths {
-		filePaths = append(filePaths, types.StringValue(filePath))
-	}
-
-	excludePaths := make([]attr.Value, 0)
-	for _, excludePath := range ofc.ExcludePaths {
-		excludePaths = append(excludePaths, types.StringValue(excludePath))
-	}
-
-	filePathsQueries := make([]attr.Value, 0)
-	for _, filePathsQuery := range ofc.FilePathsQueries {
-		filePathsQueries = append(filePathsQueries, types.StringValue(filePathsQuery))
-	}
-
 	return osqueryFileCategory{
 		ID:               types.Int64Value(int64(ofc.ID)),
 		Name:             types.StringValue(ofc.Name),
 		Description:      types.StringValue(ofc.Description),
-		FilePaths:        types.SetValueMust(types.StringType, filePaths),
-		ExcludePaths:     types.SetValueMust(types.StringType, excludePaths),
-		FilePathsQueries: types.SetValueMust(types.StringType, filePathsQueries),
+		FilePaths:        stringSetForState(ofc.FilePaths),
+		ExcludePaths:     stringSetForState(ofc.ExcludePaths),
+		FilePathsQueries: stringSetForState(ofc.FilePathsQueries),
 		AccessMonitoring: types.BoolValue(ofc.AccessMonitoring),
 	}
 }
 
 func osqueryFileCategoryRequestWithState(data osqueryFileCategory) *goztl.OsqueryFileCategoryRequest {
-	filePaths := make([]string, 0)
-	for _, filePath := range data.FilePaths.Elements() { // nil if null or unknown → no iterations
-		filePaths = append(filePaths, filePath.(types.String).ValueString())
-	}
-
-	excludePaths := make([]string, 0)
-	for _, excludePath := range data.ExcludePaths.Elements() { // nil if null or unknown → no iterations
-		excludePaths = append(excludePaths, excludePath.(types.String).ValueString())
-	}
-
-	filePathsQueries := make([]string, 0)
-	for _, filePathsQuery := range data.FilePathsQueries.Elements() { // nil if null or unknown → no iterations
-		filePathsQueries = append(filePathsQueries, filePathsQuery.(types.String).ValueString())
-	}
-
 	return &goztl.OsqueryFileCategoryRequest{
 		Name:             data.Name.ValueString(),
 		Description:      data.Description.ValueString(),
-		FilePaths:        filePaths,
-		ExcludePaths:     excludePaths,
-		FilePathsQueries: filePathsQueries,
+		FilePaths:        stringListWithStateSet(data.FilePaths),
+		ExcludePaths:     stringListWithStateSet(data.ExcludePaths),
+		FilePathsQueries: stringListWithStateSet(data.FilePathsQueries),
 		AccessMonitoring: data.AccessMonitoring.ValueBool(),
 	}
 }

--- a/internal/provider/osquery_pack.go
+++ b/internal/provider/osquery_pack.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -17,45 +16,23 @@ type osqueryPack struct {
 }
 
 func osqueryPackForState(op *goztl.OsqueryPack) osqueryPack {
-	dqs := make([]attr.Value, 0)
-	for _, dq := range op.DiscoveryQueries {
-		dqs = append(dqs, types.StringValue(dq))
-	}
-
-	var shard types.Int64
-	if op.Shard != nil {
-		shard = types.Int64Value(int64(*op.Shard))
-	} else {
-		shard = types.Int64Null()
-	}
-
 	return osqueryPack{
 		ID:               types.Int64Value(int64(op.ID)),
 		Name:             types.StringValue(op.Name),
 		Slug:             types.StringValue(op.Slug),
 		Description:      types.StringValue(op.Description),
-		DiscoveryQueries: types.ListValueMust(types.StringType, dqs),
-		Shard:            shard,
+		DiscoveryQueries: stringListForState(op.DiscoveryQueries),
+		Shard:            optionalInt64ForState(op.Shard),
 		EventRoutingKey:  types.StringValue(op.EventRoutingKey),
 	}
 }
 
 func osqueryPackRequestWithState(data osqueryPack) *goztl.OsqueryPackRequest {
-	dqs := make([]string, 0)
-	for _, dq := range data.DiscoveryQueries.Elements() { // nil if null or unknown → no iterations
-		dqs = append(dqs, dq.(types.String).ValueString())
-	}
-
-	var shard *int
-	if !data.Shard.IsNull() {
-		shard = goztl.Int(int(data.Shard.ValueInt64()))
-	}
-
 	return &goztl.OsqueryPackRequest{
 		Name:             data.Name.ValueString(),
 		Description:      data.Description.ValueString(),
-		DiscoveryQueries: dqs,
-		Shard:            shard,
+		DiscoveryQueries: stringListWithStateList(data.DiscoveryQueries),
+		Shard:            optionalIntWithState(data.Shard),
 		EventRoutingKey:  data.EventRoutingKey.ValueString(),
 	}
 }

--- a/internal/provider/osquery_query.go
+++ b/internal/provider/osquery_query.go
@@ -30,33 +30,8 @@ var schedulingAttrTypes = map[string]attr.Type{
 }
 
 func osqueryQueryForState(oq *goztl.OsqueryQuery) osqueryQuery {
-	platforms := make([]attr.Value, 0)
-	for _, platform := range oq.Platforms {
-		platforms = append(platforms, types.StringValue(platform))
-	}
-
-	var minOsqueryVersion types.String
-	if oq.MinOsqueryVersion != nil {
-		minOsqueryVersion = types.StringValue(*oq.MinOsqueryVersion)
-	} else {
-		minOsqueryVersion = types.StringNull()
-	}
-
-	var tagID types.Int64
-	if oq.TagID != nil {
-		tagID = types.Int64Value(int64(*oq.TagID))
-	} else {
-		tagID = types.Int64Null()
-	}
-
 	var scheduling types.Object
 	if oq.Scheduling != nil {
-		var shard types.Int64
-		if oq.Scheduling.Shard != nil {
-			shard = types.Int64Value(int64(*oq.Scheduling.Shard))
-		} else {
-			shard = types.Int64Null()
-		}
 		scheduling = types.ObjectValueMust(
 			schedulingAttrTypes,
 			map[string]attr.Value{
@@ -64,7 +39,7 @@ func osqueryQueryForState(oq *goztl.OsqueryQuery) osqueryQuery {
 				"log_removed_actions": types.BoolValue(oq.Scheduling.LogRemovedActions),
 				"interval":            types.Int64Value(int64(oq.Scheduling.Interval)),
 				"pack_id":             types.Int64Value(int64(oq.Scheduling.PackID)),
-				"shard":               shard,
+				"shard":               optionalInt64ForState(oq.Scheduling.Shard),
 				"snapshot_mode":       types.BoolValue(oq.Scheduling.SnapshotMode),
 			},
 		)
@@ -76,57 +51,38 @@ func osqueryQueryForState(oq *goztl.OsqueryQuery) osqueryQuery {
 		ID:                     types.Int64Value(int64(oq.ID)),
 		Name:                   types.StringValue(oq.Name),
 		SQL:                    types.StringValue(oq.SQL),
-		Platforms:              types.SetValueMust(types.StringType, platforms),
-		MinOsqueryVersion:      minOsqueryVersion,
+		Platforms:              stringSetForState(oq.Platforms),
+		MinOsqueryVersion:      optionalStringForState(oq.MinOsqueryVersion),
 		Description:            types.StringValue(oq.Description),
 		Value:                  types.StringValue(oq.Value),
 		Version:                types.Int64Value(int64(oq.Version)),
 		ComplianceCheckEnabled: types.BoolValue(oq.ComplianceCheckEnabled),
-		TagID:                  tagID,
+		TagID:                  optionalInt64ForState(oq.TagID),
 		Scheduling:             scheduling,
 	}
 }
 
 func osqueryQueryRequestWithState(data osqueryQuery) *goztl.OsqueryQueryRequest {
-	platforms := make([]string, 0)
-	for _, platform := range data.Platforms.Elements() { // nil if null or unknown → no iterations
-		platforms = append(platforms, platform.(types.String).ValueString())
-	}
-
-	var minOsqueryVersion *string
-	if !data.MinOsqueryVersion.IsNull() {
-		minOsqueryVersion = goztl.String(data.MinOsqueryVersion.ValueString())
-	}
-
-	var tagID *int
-	if !data.TagID.IsNull() {
-		tagID = goztl.Int(int(data.TagID.ValueInt64()))
-	}
-
 	req := &goztl.OsqueryQueryRequest{
 		Name:                   data.Name.ValueString(),
 		SQL:                    data.SQL.ValueString(),
-		Platforms:              platforms,
-		MinOsqueryVersion:      minOsqueryVersion,
+		Platforms:              stringListWithStateSet(data.Platforms),
+		MinOsqueryVersion:      optionalStringWithState(data.MinOsqueryVersion),
 		Description:            data.Description.ValueString(),
 		Value:                  data.Value.ValueString(),
 		ComplianceCheckEnabled: data.ComplianceCheckEnabled.ValueBool(),
-		TagID:                  tagID,
+		TagID:                  optionalIntWithState(data.TagID),
 	}
 
 	if !data.Scheduling.IsNull() {
 		schedulingMap := data.Scheduling.Attributes()
 		if schedulingMap != nil {
-			var shard *int
-			if !schedulingMap["shard"].(types.Int64).IsNull() {
-				shard = goztl.Int(int(schedulingMap["shard"].(types.Int64).ValueInt64()))
-			}
 			schReq := &goztl.OsqueryQuerySchedulingRequest{
 				CanBeDenyListed:   schedulingMap["can_be_denylisted"].(types.Bool).ValueBool(),
 				LogRemovedActions: schedulingMap["log_removed_actions"].(types.Bool).ValueBool(),
 				Interval:          int(schedulingMap["interval"].(types.Int64).ValueInt64()),
 				PackID:            int(schedulingMap["pack_id"].(types.Int64).ValueInt64()),
-				Shard:             shard,
+				Shard:             optionalIntWithState(schedulingMap["shard"].(types.Int64)),
 				SnapshotMode:      schedulingMap["snapshot_mode"].(types.Bool).ValueBool(),
 			}
 			req.Scheduling = schReq

--- a/internal/provider/probe.go
+++ b/internal/provider/probe.go
@@ -41,53 +41,25 @@ type probe struct {
 func probeForState(p *goztl.Probe) probe {
 	inventoryFilters := make([]attr.Value, 0)
 	for _, inventoryFilter := range p.InventoryFilters {
-		mbuIDs := make([]attr.Value, 0)
-		for _, mbuID := range inventoryFilter.MetaBusinessUnitIDs {
-			mbuIDs = append(mbuIDs, types.Int64Value(int64(mbuID)))
-		}
-		tagIDs := make([]attr.Value, 0)
-		for _, tagID := range inventoryFilter.TagIDs {
-			tagIDs = append(tagIDs, types.Int64Value(int64(tagID)))
-		}
-		platforms := make([]attr.Value, 0)
-		for _, platform := range inventoryFilter.Platforms {
-			platforms = append(platforms, types.StringValue(platform))
-		}
-		ts := make([]attr.Value, 0)
-		for _, t := range inventoryFilter.Types {
-			ts = append(ts, types.StringValue(t))
-		}
 		inventoryFilters = append(inventoryFilters, types.ObjectValueMust(
 			probeInventoryFilterAttrTypes,
 			map[string]attr.Value{
-				"meta_business_unit_ids": types.SetValueMust(types.Int64Type, mbuIDs),
-				"tag_ids":                types.SetValueMust(types.Int64Type, tagIDs),
-				"platforms":              types.SetValueMust(types.StringType, platforms),
-				"types":                  types.SetValueMust(types.StringType, ts),
+				"meta_business_unit_ids": int64SetForState(inventoryFilter.MetaBusinessUnitIDs),
+				"tag_ids":                int64SetForState(inventoryFilter.TagIDs),
+				"platforms":              stringSetForState(inventoryFilter.Platforms),
+				"types":                  stringSetForState(inventoryFilter.Types),
 			},
 		))
 	}
 
 	metadataFilters := make([]attr.Value, 0)
 	for _, metadataFilter := range p.MetadataFilters {
-		etys := make([]attr.Value, 0)
-		for _, eventType := range metadataFilter.EventTypes {
-			etys = append(etys, types.StringValue(eventType))
-		}
-		etas := make([]attr.Value, 0)
-		for _, eventTag := range metadataFilter.EventTags {
-			etas = append(etas, types.StringValue(eventTag))
-		}
-		erks := make([]attr.Value, 0)
-		for _, eventRoutingKey := range metadataFilter.EventRoutingKeys {
-			erks = append(erks, types.StringValue(eventRoutingKey))
-		}
 		metadataFilters = append(metadataFilters, types.ObjectValueMust(
 			probeMetadataFilterAttrTypes,
 			map[string]attr.Value{
-				"event_types":        types.SetValueMust(types.StringType, etys),
-				"event_tags":         types.SetValueMust(types.StringType, etas),
-				"event_routing_keys": types.SetValueMust(types.StringType, erks),
+				"event_types":        stringSetForState(metadataFilter.EventTypes),
+				"event_tags":         stringSetForState(metadataFilter.EventTags),
+				"event_routing_keys": stringSetForState(metadataFilter.EventRoutingKeys),
 			},
 		))
 	}
@@ -96,32 +68,16 @@ func probeForState(p *goztl.Probe) probe {
 	for _, payloadFilterItems := range p.PayloadFilters {
 		pfis := make([]attr.Value, 0)
 		for _, payloadFilterItem := range payloadFilterItems {
-			vals := make([]attr.Value, 0)
-			for _, val := range payloadFilterItem.Values {
-				vals = append(vals, types.StringValue(val))
-			}
 			pfis = append(pfis, types.ObjectValueMust(
 				probePayloadFilterItemAttrTypes,
 				map[string]attr.Value{
 					"attribute": types.StringValue(payloadFilterItem.Attribute),
 					"operator":  types.StringValue(payloadFilterItem.Operator),
-					"values":    types.SetValueMust(types.StringType, vals),
+					"values":    stringSetForState(payloadFilterItem.Values),
 				},
 			))
 		}
 		payloadFilters = append(payloadFilters, types.SetValueMust(types.ObjectType{AttrTypes: probePayloadFilterItemAttrTypes}, pfis))
-	}
-
-	actionIDs := make([]attr.Value, 0)
-	for _, actionID := range p.ActionIDs {
-		actionIDs = append(actionIDs, types.StringValue(actionID))
-	}
-
-	var incidentSeverity types.Int64
-	if p.IncidentSeverity != nil {
-		incidentSeverity = types.Int64Value(int64(*p.IncidentSeverity))
-	} else {
-		incidentSeverity = types.Int64Null()
 	}
 
 	return probe{
@@ -133,8 +89,8 @@ func probeForState(p *goztl.Probe) probe {
 		MetadataFilters:  types.SetValueMust(types.ObjectType{AttrTypes: probeMetadataFilterAttrTypes}, metadataFilters),
 		PayloadFilters:   types.SetValueMust(types.SetType{ElemType: types.ObjectType{AttrTypes: probePayloadFilterItemAttrTypes}}, payloadFilters),
 		Active:           types.BoolValue(p.Active),
-		ActionIDs:        types.SetValueMust(types.StringType, actionIDs),
-		IncidentSeverity: incidentSeverity,
+		ActionIDs:        stringSetForState(p.ActionIDs),
+		IncidentSeverity: optionalInt64ForState(p.IncidentSeverity),
 	}
 }
 
@@ -142,49 +98,21 @@ func probeRequestWithState(data probe) *goztl.ProbeRequest {
 	inventoryFilters := make([]goztl.InventoryFilter, 0)
 	for _, inventoryFilter := range data.InventoryFilters.Elements() {
 		inventoryFilterAttrs := inventoryFilter.(types.Object).Attributes()
-		mbuIDs := make([]int, 0)
-		for _, mbuID := range inventoryFilterAttrs["meta_business_unit_ids"].(types.Set).Elements() {
-			mbuIDs = append(mbuIDs, int(mbuID.(types.Int64).ValueInt64()))
-		}
-		tagIDs := make([]int, 0)
-		for _, tagID := range inventoryFilterAttrs["tag_ids"].(types.Set).Elements() {
-			tagIDs = append(tagIDs, int(tagID.(types.Int64).ValueInt64()))
-		}
-		platforms := make([]string, 0)
-		for _, platform := range inventoryFilterAttrs["platforms"].(types.Set).Elements() {
-			platforms = append(platforms, platform.(types.String).ValueString())
-		}
-		ts := make([]string, 0)
-		for _, t := range inventoryFilterAttrs["types"].(types.Set).Elements() {
-			ts = append(ts, t.(types.String).ValueString())
-		}
 		inventoryFilters = append(inventoryFilters, goztl.InventoryFilter{
-			MetaBusinessUnitIDs: mbuIDs,
-			TagIDs:              tagIDs,
-			Platforms:           platforms,
-			Types:               ts,
+			MetaBusinessUnitIDs: intListWithState(inventoryFilterAttrs["meta_business_unit_ids"].(types.Set)),
+			TagIDs:              intListWithState(inventoryFilterAttrs["tag_ids"].(types.Set)),
+			Platforms:           stringListWithStateSet(inventoryFilterAttrs["platforms"].(types.Set)),
+			Types:               stringListWithStateSet(inventoryFilterAttrs["types"].(types.Set)),
 		})
 	}
 
 	metadataFilters := make([]goztl.MetadataFilter, 0)
 	for _, metadataFilter := range data.MetadataFilters.Elements() {
 		metadataFilterAttrs := metadataFilter.(types.Object).Attributes()
-		etys := make([]string, 0)
-		for _, eventType := range metadataFilterAttrs["event_types"].(types.Set).Elements() {
-			etys = append(etys, eventType.(types.String).ValueString())
-		}
-		etas := make([]string, 0)
-		for _, eventTag := range metadataFilterAttrs["event_tags"].(types.Set).Elements() {
-			etas = append(etas, eventTag.(types.String).ValueString())
-		}
-		erks := make([]string, 0)
-		for _, eventRoutingKey := range metadataFilterAttrs["event_routing_keys"].(types.Set).Elements() {
-			erks = append(erks, eventRoutingKey.(types.String).ValueString())
-		}
 		metadataFilters = append(metadataFilters, goztl.MetadataFilter{
-			EventTypes:       etys,
-			EventTags:        etas,
-			EventRoutingKeys: erks,
+			EventTypes:       stringListWithStateSet(metadataFilterAttrs["event_types"].(types.Set)),
+			EventTags:        stringListWithStateSet(metadataFilterAttrs["event_tags"].(types.Set)),
+			EventRoutingKeys: stringListWithStateSet(metadataFilterAttrs["event_routing_keys"].(types.Set)),
 		})
 	}
 
@@ -193,27 +121,13 @@ func probeRequestWithState(data probe) *goztl.ProbeRequest {
 		pfis := make([]goztl.PayloadFilterItem, 0)
 		for _, payloadFilterItem := range payloadFilter.(types.Set).Elements() {
 			payloadFilterItemAttrs := payloadFilterItem.(types.Object).Attributes()
-			vals := make([]string, 0)
-			for _, val := range payloadFilterItemAttrs["values"].(types.Set).Elements() {
-				vals = append(vals, val.(types.String).ValueString())
-			}
 			pfis = append(pfis, goztl.PayloadFilterItem{
 				Attribute: payloadFilterItemAttrs["attribute"].(types.String).ValueString(),
 				Operator:  payloadFilterItemAttrs["operator"].(types.String).ValueString(),
-				Values:    vals,
+				Values:    stringListWithStateSet(payloadFilterItemAttrs["values"].(types.Set)),
 			})
 		}
 		payloadFilters = append(payloadFilters, pfis)
-	}
-
-	actionIDs := make([]string, 0)
-	for _, actionID := range data.ActionIDs.Elements() {
-		actionIDs = append(actionIDs, actionID.(types.String).ValueString())
-	}
-
-	var incidentSeverity *int
-	if !data.IncidentSeverity.IsNull() {
-		incidentSeverity = goztl.Int(int(data.IncidentSeverity.ValueInt64()))
 	}
 
 	req := &goztl.ProbeRequest{
@@ -223,8 +137,8 @@ func probeRequestWithState(data probe) *goztl.ProbeRequest {
 		MetadataFilters:  metadataFilters,
 		PayloadFilters:   payloadFilters,
 		Active:           data.Active.ValueBool(),
-		ActionIDs:        actionIDs,
-		IncidentSeverity: incidentSeverity,
+		ActionIDs:        stringListWithStateSet(data.ActionIDs),
+		IncidentSeverity: optionalIntWithState(data.IncidentSeverity),
 	}
 
 	return req

--- a/internal/provider/santa_configuration.go
+++ b/internal/provider/santa_configuration.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -33,11 +32,6 @@ type santaConfiguration struct {
 
 func santaConfigurationForState(sc *goztl.SantaConfiguration) santaConfiguration {
 
-	remountUSBModes := make([]attr.Value, 0)
-	for _, rumv := range sc.RemountUSBMode {
-		remountUSBModes = append(remountUSBModes, types.StringValue(rumv))
-	}
-
 	clientMode := tfSantaMonitor // default to MONITOR
 	if sc.ClientMode == ztlSantaLockdown {
 		clientMode = tfSantaLockdown
@@ -55,7 +49,7 @@ func santaConfigurationForState(sc *goztl.SantaConfiguration) santaConfiguration
 		AllowedPathRegex:          types.StringValue(sc.AllowedPathRegex),
 		BlockedPathRegex:          types.StringValue(sc.BlockedPathRegex),
 		BlockUSBMount:             types.BoolValue(sc.BlockUSBMount),
-		RemountUSBMode:            types.SetValueMust(types.StringType, remountUSBModes),
+		RemountUSBMode:            stringSetForState(sc.RemountUSBMode),
 		AllowUnknownShard:         types.Int64Value(int64(sc.AllowUnknownShard)),
 		EnableAllEventUploadShard: types.Int64Value(int64(sc.EnableAllEventUploadShard)),
 		SyncIncidentSeverity:      types.Int64Value(int64(sc.SyncIncidentSeverity)),
@@ -63,11 +57,6 @@ func santaConfigurationForState(sc *goztl.SantaConfiguration) santaConfiguration
 }
 
 func santaConfigurationRequestWithState(data santaConfiguration) *goztl.SantaConfigurationRequest {
-	remountUSBMode := make([]string, 0)
-	for _, rumv := range data.RemountUSBMode.Elements() { // nil if null or unknown → no iterations
-		remountUSBMode = append(remountUSBMode, rumv.(types.String).ValueString())
-	}
-
 	clientMode := ztlSantaMonitor // default to MONITOR
 	if data.ClientMode.ValueString() == tfSantaLockdown {
 		clientMode = ztlSantaLockdown
@@ -84,7 +73,7 @@ func santaConfigurationRequestWithState(data santaConfiguration) *goztl.SantaCon
 		AllowedPathRegex:          data.AllowedPathRegex.ValueString(),
 		BlockedPathRegex:          data.BlockedPathRegex.ValueString(),
 		BlockUSBMount:             data.BlockUSBMount.ValueBool(),
-		RemountUSBMode:            remountUSBMode,
+		RemountUSBMode:            stringListWithStateSet(data.RemountUSBMode),
 		AllowUnknownShard:         int(data.AllowUnknownShard.ValueInt64()),
 		EnableAllEventUploadShard: int(data.EnableAllEventUploadShard.ValueInt64()),
 		SyncIncidentSeverity:      int(data.SyncIncidentSeverity.ValueInt64()),

--- a/internal/provider/santa_enrollment.go
+++ b/internal/provider/santa_enrollment.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -23,28 +22,6 @@ type santaEnrollment struct {
 
 func santaEnrollmentForState(se *goztl.SantaEnrollment) santaEnrollment {
 
-	tagIDs := make([]attr.Value, 0)
-	for _, tagID := range se.Secret.TagIDs {
-		tagIDs = append(tagIDs, types.Int64Value(int64(tagID)))
-	}
-
-	serialNumbers := make([]attr.Value, 0)
-	for _, serialNumber := range se.Secret.SerialNumbers {
-		serialNumbers = append(serialNumbers, types.StringValue(serialNumber))
-	}
-
-	udids := make([]attr.Value, 0)
-	for _, udid := range se.Secret.UDIDs {
-		udids = append(udids, types.StringValue(udid))
-	}
-
-	var quota types.Int64
-	if se.Secret.Quota != nil {
-		quota = types.Int64Value(int64(*se.Secret.Quota))
-	} else {
-		quota = types.Int64Null()
-	}
-
 	return santaEnrollment{
 		ID:               types.Int64Value(int64(se.ID)),
 		ConfigurationID:  types.Int64Value(int64(se.ConfigurationID)),
@@ -54,42 +31,22 @@ func santaEnrollmentForState(se *goztl.SantaEnrollment) santaEnrollment {
 		// enrollment secret
 		Secret:             types.StringValue(se.Secret.Secret),
 		MetaBusinessUnitID: types.Int64Value(int64(se.Secret.MetaBusinessUnitID)),
-		TagIDs:             types.SetValueMust(types.Int64Type, tagIDs),
-		SerialNumbers:      types.SetValueMust(types.StringType, serialNumbers),
-		UDIDs:              types.SetValueMust(types.StringType, udids),
-		Quota:              quota,
+		TagIDs:             int64SetForState(se.Secret.TagIDs),
+		SerialNumbers:      stringSetForState(se.Secret.SerialNumbers),
+		UDIDs:              stringSetForState(se.Secret.UDIDs),
+		Quota:              optionalInt64ForState(se.Secret.Quota),
 	}
 }
 
 func santaEnrollmentRequestWithState(data santaEnrollment) *goztl.SantaEnrollmentRequest {
-	tagIDs := make([]int, 0)
-	for _, tagID := range data.TagIDs.Elements() { // nil if null or unknown → no iterations
-		tagIDs = append(tagIDs, int(tagID.(types.Int64).ValueInt64()))
-	}
-
-	serialNumbers := make([]string, 0)
-	for _, serialNumber := range data.SerialNumbers.Elements() { // nil if null or unknown → no iterations
-		serialNumbers = append(serialNumbers, serialNumber.(types.String).ValueString())
-	}
-
-	udids := make([]string, 0)
-	for _, udid := range data.UDIDs.Elements() { // nil if null or unknown → no iterations
-		udids = append(udids, udid.(types.String).ValueString())
-	}
-
-	santaEnrollmentRequest := &goztl.SantaEnrollmentRequest{
+	return &goztl.SantaEnrollmentRequest{
 		ConfigurationID: int(data.ConfigurationID.ValueInt64()),
 		Secret: goztl.EnrollmentSecretRequest{
 			MetaBusinessUnitID: int(data.MetaBusinessUnitID.ValueInt64()),
-			TagIDs:             tagIDs,
-			SerialNumbers:      serialNumbers,
-			UDIDs:              udids,
+			TagIDs:             intListWithState(data.TagIDs),
+			SerialNumbers:      stringListWithStateSet(data.SerialNumbers),
+			UDIDs:              stringListWithStateSet(data.UDIDs),
+			Quota:              optionalIntWithState(data.Quota),
 		},
 	}
-
-	if !data.Quota.IsNull() {
-		santaEnrollmentRequest.Secret.Quota = goztl.Int(int(data.Quota.ValueInt64()))
-	}
-
-	return santaEnrollmentRequest
 }

--- a/internal/provider/santa_rule.go
+++ b/internal/provider/santa_rule.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zentralopensource/goztl"
 )
@@ -56,43 +55,6 @@ func santaRuleForState(sr *goztl.SantaRule) santaRule {
 		panic("Unknown Santa rule policy")
 	}
 
-	var rulesetID types.Int64
-	if sr.RulesetID != nil {
-		rulesetID = types.Int64Value(int64(*sr.RulesetID))
-	} else {
-		rulesetID = types.Int64Null()
-	}
-
-	primaryUsers := make([]attr.Value, 0)
-	for _, primaryUser := range sr.PrimaryUsers {
-		primaryUsers = append(primaryUsers, types.StringValue(primaryUser))
-	}
-
-	excludedPrimaryUsers := make([]attr.Value, 0)
-	for _, primaryUser := range sr.ExcludedPrimaryUsers {
-		excludedPrimaryUsers = append(excludedPrimaryUsers, types.StringValue(primaryUser))
-	}
-
-	serialNumbers := make([]attr.Value, 0)
-	for _, serialNumber := range sr.SerialNumbers {
-		serialNumbers = append(serialNumbers, types.StringValue(serialNumber))
-	}
-
-	excludedSerialNumbers := make([]attr.Value, 0)
-	for _, serialNumber := range sr.ExcludedSerialNumbers {
-		excludedSerialNumbers = append(excludedSerialNumbers, types.StringValue(serialNumber))
-	}
-
-	tagIDs := make([]attr.Value, 0)
-	for _, tagID := range sr.TagIDs {
-		tagIDs = append(tagIDs, types.Int64Value(int64(tagID)))
-	}
-
-	excludedTagIDs := make([]attr.Value, 0)
-	for _, tagID := range sr.ExcludedTagIDs {
-		excludedTagIDs = append(excludedTagIDs, types.Int64Value(int64(tagID)))
-	}
-
 	return santaRule{
 		ID:                    types.Int64Value(int64(sr.ID)),
 		ConfigurationID:       types.Int64Value(int64(sr.ConfigurationID)),
@@ -103,13 +65,13 @@ func santaRuleForState(sr *goztl.SantaRule) santaRule {
 		Description:           types.StringValue(sr.Description),
 		CustomMessage:         types.StringValue(sr.CustomMessage),
 		CustomURL:             types.StringValue(sr.CustomURL),
-		RulesetID:             rulesetID,
-		PrimaryUsers:          types.SetValueMust(types.StringType, primaryUsers),
-		ExcludedPrimaryUsers:  types.SetValueMust(types.StringType, excludedPrimaryUsers),
-		SerialNumbers:         types.SetValueMust(types.StringType, serialNumbers),
-		ExcludedSerialNumbers: types.SetValueMust(types.StringType, excludedSerialNumbers),
-		TagIDs:                types.SetValueMust(types.Int64Type, tagIDs),
-		ExcludedTagIDs:        types.SetValueMust(types.Int64Type, excludedTagIDs),
+		RulesetID:             optionalInt64ForState(sr.RulesetID),
+		PrimaryUsers:          stringSetForState(sr.PrimaryUsers),
+		ExcludedPrimaryUsers:  stringSetForState(sr.ExcludedPrimaryUsers),
+		SerialNumbers:         stringSetForState(sr.SerialNumbers),
+		ExcludedSerialNumbers: stringSetForState(sr.ExcludedSerialNumbers),
+		TagIDs:                int64SetForState(sr.TagIDs),
+		ExcludedTagIDs:        int64SetForState(sr.ExcludedTagIDs),
 		Version:               types.Int64Value(int64(sr.Version)),
 	}
 }
@@ -131,36 +93,6 @@ func santaRuleRequestWithState(data santaRule) *goztl.SantaRuleRequest {
 		panic("Unknown Santa rule policy")
 	}
 
-	primaryUsers := make([]string, 0)
-	for _, primaryUser := range data.PrimaryUsers.Elements() { // nil if null or unknown → no iterations
-		primaryUsers = append(primaryUsers, primaryUser.(types.String).ValueString())
-	}
-
-	excludedPrimaryUsers := make([]string, 0)
-	for _, primaryUser := range data.ExcludedPrimaryUsers.Elements() { // nil if null or unknown → no iterations
-		excludedPrimaryUsers = append(excludedPrimaryUsers, primaryUser.(types.String).ValueString())
-	}
-
-	serialNumbers := make([]string, 0)
-	for _, serialNumber := range data.SerialNumbers.Elements() { // nil if null or unknown → no iterations
-		serialNumbers = append(serialNumbers, serialNumber.(types.String).ValueString())
-	}
-
-	excludedSerialNumbers := make([]string, 0)
-	for _, serialNumber := range data.ExcludedSerialNumbers.Elements() { // nil if null or unknown → no iterations
-		excludedSerialNumbers = append(excludedSerialNumbers, serialNumber.(types.String).ValueString())
-	}
-
-	tagIDs := make([]int, 0)
-	for _, tagID := range data.TagIDs.Elements() { // nil if null or unknown → no iterations
-		tagIDs = append(tagIDs, int(tagID.(types.Int64).ValueInt64()))
-	}
-
-	excludedTagIDs := make([]int, 0)
-	for _, tagID := range data.ExcludedTagIDs.Elements() { // nil if null or unknown → no iterations
-		excludedTagIDs = append(excludedTagIDs, int(tagID.(types.Int64).ValueInt64()))
-	}
-
 	return &goztl.SantaRuleRequest{
 		ConfigurationID:       int(data.ConfigurationID.ValueInt64()),
 		Policy:                policy,
@@ -170,11 +102,11 @@ func santaRuleRequestWithState(data santaRule) *goztl.SantaRuleRequest {
 		Description:           data.Description.ValueString(),
 		CustomMessage:         data.CustomMessage.ValueString(),
 		CustomURL:             data.CustomURL.ValueString(),
-		PrimaryUsers:          primaryUsers,
-		ExcludedPrimaryUsers:  excludedPrimaryUsers,
-		SerialNumbers:         serialNumbers,
-		ExcludedSerialNumbers: excludedSerialNumbers,
-		TagIDs:                tagIDs,
-		ExcludedTagIDs:        excludedTagIDs,
+		PrimaryUsers:          stringListWithStateSet(data.PrimaryUsers),
+		ExcludedPrimaryUsers:  stringListWithStateSet(data.ExcludedPrimaryUsers),
+		SerialNumbers:         stringListWithStateSet(data.SerialNumbers),
+		ExcludedSerialNumbers: stringListWithStateSet(data.ExcludedSerialNumbers),
+		TagIDs:                intListWithState(data.TagIDs),
+		ExcludedTagIDs:        intListWithState(data.ExcludedTagIDs),
 	}
 }

--- a/internal/provider/tag.go
+++ b/internal/provider/tag.go
@@ -13,15 +13,9 @@ type tag struct {
 }
 
 func tagForState(t *goztl.Tag) tag {
-	var taxonomyID types.Int64
-	if t.TaxonomyID != nil {
-		taxonomyID = types.Int64Value(int64(*t.TaxonomyID))
-	} else {
-		taxonomyID = types.Int64Null()
-	}
 	return tag{
 		ID:         types.Int64Value(int64(t.ID)),
-		TaxonomyID: taxonomyID,
+		TaxonomyID: optionalInt64ForState(t.TaxonomyID),
 		Name:       types.StringValue(t.Name),
 		Color:      types.StringValue(t.Color),
 	}

--- a/internal/provider/tag_resource.go
+++ b/internal/provider/tag_resource.go
@@ -94,11 +94,9 @@ func (r *TagResource) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 
 	tagCreateRequest := &goztl.TagCreateRequest{
-		Name:  data.Name.ValueString(),
-		Color: data.Color.ValueString(),
-	}
-	if !data.TaxonomyID.IsNull() {
-		tagCreateRequest.TaxonomyID = goztl.Int(int(data.TaxonomyID.ValueInt64()))
+		Name:       data.Name.ValueString(),
+		Color:      data.Color.ValueString(),
+		TaxonomyID: optionalIntWithState(data.TaxonomyID),
 	}
 	tag, _, err := r.client.Tags.Create(ctx, tagCreateRequest)
 	if err != nil {
@@ -151,11 +149,9 @@ func (r *TagResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	tagUpdateRequest := &goztl.TagUpdateRequest{
-		Name:  data.Name.ValueString(),
-		Color: data.Color.ValueString(),
-	}
-	if !data.TaxonomyID.IsNull() {
-		tagUpdateRequest.TaxonomyID = goztl.Int(int(data.TaxonomyID.ValueInt64()))
+		Name:       data.Name.ValueString(),
+		Color:      data.Color.ValueString(),
+		TaxonomyID: optionalIntWithState(data.TaxonomyID),
 	}
 	tag, _, err := r.client.Tags.Update(ctx, int(data.ID.ValueInt64()), tagUpdateRequest)
 	if err != nil {


### PR DESCRIPTION
The state ↔ goztl conversion helpers in `common.go` landed a while ago, but most resources still hand-rolled the loops and null checks they replace. This converts **145 sites across 29 files** — +153 / −912.

| Helper | Sites | | Helper | Sites |
|---|---|---|---|---|
| `stringListWithStateSet` | 32 | | `optionalInt64ForState` | 14 |
| `stringSetForState` | 31 | | `optionalIntWithState` | 13 |
| `intListWithState` | 20 | | `optionalStringForState` | 7 |
| `int64SetForState` | 19 | | `stringListForState` / `…WithStateList` | 3 / 3 |
| | | | `optionalStringWithState` | 3 |

Every one is an exact substitution:

- **Null-vs-empty is unchanged.** No site had the empty-to-null shape of `nullableStringSetForState` — the only `SetNull` outside `common.go` is an unrelated string check — so what lands in state is identical.
- **The List/Set distinction is preserved per field**, resolved through each variable's struct type rather than the field name, since `Platforms` and `TagIDs` are `Set` in some structs and `List` in others. The compiler backstops it: a wrong pick doesn't build.
- The enrollment `quota` and tag `taxonomy_id` moved into their request literals now that `optionalIntWithState` yields nil for a null value — which is what the trailing `if !x.IsNull()` blocks were doing by hand.

### Left open-coded, on purpose

- The object-set builders — tag shards, cert asset RDNs, the probe inventory/metadata/payload filters — build `types.Object` sets, and no helper covers that shape.
- `mdm_software_update_enforcement.go`'s `delay_days` / `local_time`. These don't just map null → nil: on unknown they send the values that mirror Zentral's own model defaults, and the request struct has no `omitempty`, so a nil pointer would reach the server as an explicit null rather than as an absent key. Converting them would change what gets stored. There's a follow-up worth having here to remove the duplicated constants.

### Verified

gofmt, `go build`, `go vet`, `go test ./...` and `go generate ./...` (zero docs diff) all clean, plus a full acceptance run against a test server: **96 passed, 0 failed, 0 skipped**. That is the meaningful check here — every resource round-trips create → read → update → import with state matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)