### PR TITLE
Add the compliance check IDs to the checks

### DIFF
--- a/docs/data-sources/jmespath_check.md
+++ b/docs/data-sources/jmespath_check.md
@@ -22,6 +22,7 @@ The data source `zentral_jmespath_check` allows details of a JMESPath compliance
 
 ### Read-Only
 
+- `compliance_check_id` (Number) `ID` of the compliance check backing this JMESPath check.
 - `description` (String) Description of the JMESPath compliance check.
 - `jmespath_expression` (String) The JMESPath compliance check expression.
 - `platforms` (Set of String) The platforms the JMESPath compliance check is restricted to.

--- a/docs/data-sources/munki_script_check.md
+++ b/docs/data-sources/munki_script_check.md
@@ -24,6 +24,7 @@ The data source `zentral_munki_script_check` allows details of a Munki script ch
 
 - `arch_amd64` (Boolean) If `true`, this Munki script check is scheduled on Intel machines.
 - `arch_arm64` (Boolean) If `true`, this Munki script check is scheduled on Apple Silicon machines.
+- `compliance_check_id` (Number) `ID` of the compliance check backing this script check.
 - `description` (String) Description of the Munki script check.
 - `excluded_tag_ids` (Set of Number) The IDs of the tags this Munki script check is not scoped to.
 - `expected_result` (String) Expected result of the Munki script check.

--- a/docs/data-sources/osquery_query.md
+++ b/docs/data-sources/osquery_query.md
@@ -25,6 +25,7 @@ The data source `zentral_osquery_query` allows details of a Osquery query to be 
 ### Read-Only
 
 - `compliance_check_enabled` (Boolean) If `true`, the query will be used as compliance check. Defaults to `false`.
+- `compliance_check_id` (Number) `ID` of the compliance check backing this query, when `compliance_check_enabled` is `true`.
 - `description` (String) Description of the query.
 - `minimum_osquery_version` (String) Only run on Osquery versions greater than or equal-to this version string
 - `platforms` (Set of String) Restrict the query to some platforms, default is 'all' platforms

--- a/docs/resources/jmespath_check.md
+++ b/docs/resources/jmespath_check.md
@@ -29,5 +29,6 @@ The resource `zentral_jmespath_check` manages JMESPath compliance checks.
 
 ### Read-Only
 
+- `compliance_check_id` (Number) `ID` of the compliance check backing this JMESPath check.
 - `id` (Number) `ID` of the JMESPath compliance check.
 - `version` (Number) The JMESPath compliance check version.

--- a/docs/resources/munki_script_check.md
+++ b/docs/resources/munki_script_check.md
@@ -34,5 +34,6 @@ The resource `zentral_munki_script_check` manages Munki script checks.
 
 ### Read-Only
 
+- `compliance_check_id` (Number) `ID` of the compliance check backing this script check.
 - `id` (Number) `ID` of the Munki script check.
 - `version` (Number) Version of the Munki script check.

--- a/docs/resources/osquery_query.md
+++ b/docs/resources/osquery_query.md
@@ -32,6 +32,7 @@ The resource `zentral_osquery_query` manages Osquery queries.
 
 ### Read-Only
 
+- `compliance_check_id` (Number) `ID` of the compliance check backing this query, when `compliance_check_enabled` is `true`.
 - `id` (Number) `ID` of the query.
 - `version` (Number) Version of the query.
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
-	github.com/zentralopensource/goztl v0.1.77
+	github.com/zentralopensource/goztl v0.1.78
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,10 @@ github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 github.com/zentralopensource/goztl v0.1.77 h1:yZQouidVe/Xx7Tdo8t5rL1OCniHJHT2z4HSEKX8ZaOY=
 github.com/zentralopensource/goztl v0.1.77/go.mod h1:v7QVp73QeJM1WRffCmxzMEd/2q1K33050U2aep+fYD0=
+github.com/zentralopensource/goztl v0.1.78-0.20260808152117-2b7989ba69e6 h1:1nQrpo7Myn4zCcAEr4jsuXIToc+H6PrZpQV3PqiZCJU=
+github.com/zentralopensource/goztl v0.1.78-0.20260808152117-2b7989ba69e6/go.mod h1:v7QVp73QeJM1WRffCmxzMEd/2q1K33050U2aep+fYD0=
+github.com/zentralopensource/goztl v0.1.78 h1:FIlyYMCwkKpU4X8bL6UiCSj1K43AgzyRnDdEYtBonbs=
+github.com/zentralopensource/goztl v0.1.78/go.mod h1:v7QVp73QeJM1WRffCmxzMEd/2q1K33050U2aep+fYD0=
 go.abhg.dev/goldmark/frontmatter v0.2.0 h1:P8kPG0YkL12+aYk2yU3xHv4tcXzeVnN+gU0tJ5JnxRw=
 go.abhg.dev/goldmark/frontmatter v0.2.0/go.mod h1:XqrEkZuM57djk7zrlRUB02x8I5J0px76YjkOzhB4YlU=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/provider/jmespath_check.go
+++ b/internal/provider/jmespath_check.go
@@ -14,6 +14,7 @@ type jmespathCheck struct {
 	TagIDs             types.Set    `tfsdk:"tag_ids"`
 	JMESPathExpression types.String `tfsdk:"jmespath_expression"`
 	Version            types.Int64  `tfsdk:"version"`
+	ComplianceCheckID  types.Int64  `tfsdk:"compliance_check_id"`
 }
 
 func jmespathCheckForState(j *goztl.JMESPathCheck) jmespathCheck {
@@ -26,5 +27,6 @@ func jmespathCheckForState(j *goztl.JMESPathCheck) jmespathCheck {
 		TagIDs:             int64SetForState(j.TagIDs),
 		JMESPathExpression: types.StringValue(j.JMESPathExpression),
 		Version:            types.Int64Value(int64(j.Version)),
+		ComplianceCheckID:  types.Int64Value(int64(j.ComplianceCheckID)),
 	}
 }

--- a/internal/provider/jmespath_check_data_source.go
+++ b/internal/provider/jmespath_check_data_source.go
@@ -74,6 +74,11 @@ func (d *JMESPathCheckDataSource) Schema(ctx context.Context, req datasource.Sch
 				MarkdownDescription: "The JMESPath compliance check version.",
 				Computed:            true,
 			},
+			"compliance_check_id": schema.Int64Attribute{
+				Description:         "ID of the compliance check backing this JMESPath check.",
+				MarkdownDescription: "`ID` of the compliance check backing this JMESPath check.",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/jmespath_check_data_source_test.go
+++ b/internal/provider/jmespath_check_data_source_test.go
@@ -44,6 +44,8 @@ func TestAccJMESPathCheckDataSource(t *testing.T) {
 						ds1ResourceName, "tag_ids.*", tagResourceName, "id"),
 					resource.TestCheckResourceAttr(
 						ds1ResourceName, "jmespath_expression", "ok1"),
+					resource.TestCheckResourceAttrSet(
+						ds1ResourceName, "compliance_check_id"),
 					// Read by ID, no platforms, no tags
 					resource.TestCheckResourceAttrPair(
 						ds2ResourceName, "id", c2ResourceName, "id"),
@@ -59,6 +61,8 @@ func TestAccJMESPathCheckDataSource(t *testing.T) {
 						ds2ResourceName, "tag_ids.#", "0"),
 					resource.TestCheckResourceAttr(
 						ds2ResourceName, "jmespath_expression", "ok2"),
+					resource.TestCheckResourceAttrSet(
+						ds2ResourceName, "compliance_check_id"),
 				),
 			},
 		},

--- a/internal/provider/jmespath_check_resource.go
+++ b/internal/provider/jmespath_check_resource.go
@@ -84,6 +84,11 @@ func (r *JMESPathCheckResource) Schema(ctx context.Context, req resource.SchemaR
 				MarkdownDescription: "The JMESPath compliance check version.",
 				Computed:            true,
 			},
+			"compliance_check_id": schema.Int64Attribute{
+				Description:         "ID of the compliance check backing this JMESPath check.",
+				MarkdownDescription: "`ID` of the compliance check backing this JMESPath check.",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/jmespath_check_resource_test.go
+++ b/internal/provider/jmespath_check_resource_test.go
@@ -37,6 +37,8 @@ func TestAccJMESPathCheckResource(t *testing.T) {
 						resourceName, "tag_ids.#", "0"),
 					resource.TestCheckResourceAttr(
 						resourceName, "jmespath_expression", "ok"),
+					resource.TestCheckResourceAttrSet(
+						resourceName, "compliance_check_id"),
 				),
 			},
 			// ImportState
@@ -69,6 +71,8 @@ func TestAccJMESPathCheckResource(t *testing.T) {
 						resourceName, "tag_ids.*", t2Resource, "id"),
 					resource.TestCheckResourceAttr(
 						resourceName, "jmespath_expression", "ok"),
+					resource.TestCheckResourceAttrSet(
+						resourceName, "compliance_check_id"),
 				),
 			},
 			// ImportState

--- a/internal/provider/munki_script_check.go
+++ b/internal/provider/munki_script_check.go
@@ -6,36 +6,38 @@ import (
 )
 
 type munkiScriptCheck struct {
-	ID             types.Int64  `tfsdk:"id"`
-	Name           types.String `tfsdk:"name"`
-	Description    types.String `tfsdk:"description"`
-	Type           types.String `tfsdk:"type"`
-	Source         types.String `tfsdk:"source"`
-	ExpectedResult types.String `tfsdk:"expected_result"`
-	ArchAMD64      types.Bool   `tfsdk:"arch_amd64"`
-	ArchARM64      types.Bool   `tfsdk:"arch_arm64"`
-	MinOSVersion   types.String `tfsdk:"min_os_version"`
-	MaxOSVersion   types.String `tfsdk:"max_os_version"`
-	TagIDs         types.Set    `tfsdk:"tag_ids"`
-	ExcludedTagIDs types.Set    `tfsdk:"excluded_tag_ids"`
-	Version        types.Int64  `tfsdk:"version"`
+	ID                types.Int64  `tfsdk:"id"`
+	Name              types.String `tfsdk:"name"`
+	Description       types.String `tfsdk:"description"`
+	Type              types.String `tfsdk:"type"`
+	Source            types.String `tfsdk:"source"`
+	ExpectedResult    types.String `tfsdk:"expected_result"`
+	ArchAMD64         types.Bool   `tfsdk:"arch_amd64"`
+	ArchARM64         types.Bool   `tfsdk:"arch_arm64"`
+	MinOSVersion      types.String `tfsdk:"min_os_version"`
+	MaxOSVersion      types.String `tfsdk:"max_os_version"`
+	TagIDs            types.Set    `tfsdk:"tag_ids"`
+	ExcludedTagIDs    types.Set    `tfsdk:"excluded_tag_ids"`
+	Version           types.Int64  `tfsdk:"version"`
+	ComplianceCheckID types.Int64  `tfsdk:"compliance_check_id"`
 }
 
 func munkiScriptCheckForState(msc *goztl.MunkiScriptCheck) munkiScriptCheck {
 	return munkiScriptCheck{
-		ID:             types.Int64Value(int64(msc.ID)),
-		Name:           types.StringValue(msc.Name),
-		Description:    types.StringValue(msc.Description),
-		Type:           types.StringValue(msc.Type),
-		Source:         types.StringValue(msc.Source),
-		ExpectedResult: types.StringValue(msc.ExpectedResult),
-		ArchAMD64:      types.BoolValue(msc.ArchAMD64),
-		ArchARM64:      types.BoolValue(msc.ArchARM64),
-		MinOSVersion:   types.StringValue(msc.MinOSVersion),
-		MaxOSVersion:   types.StringValue(msc.MaxOSVersion),
-		TagIDs:         int64SetForState(msc.TagIDs),
-		ExcludedTagIDs: int64SetForState(msc.ExcludedTagIDs),
-		Version:        types.Int64Value(int64(msc.Version)),
+		ID:                types.Int64Value(int64(msc.ID)),
+		Name:              types.StringValue(msc.Name),
+		Description:       types.StringValue(msc.Description),
+		Type:              types.StringValue(msc.Type),
+		Source:            types.StringValue(msc.Source),
+		ExpectedResult:    types.StringValue(msc.ExpectedResult),
+		ArchAMD64:         types.BoolValue(msc.ArchAMD64),
+		ArchARM64:         types.BoolValue(msc.ArchARM64),
+		MinOSVersion:      types.StringValue(msc.MinOSVersion),
+		MaxOSVersion:      types.StringValue(msc.MaxOSVersion),
+		TagIDs:            int64SetForState(msc.TagIDs),
+		ExcludedTagIDs:    int64SetForState(msc.ExcludedTagIDs),
+		Version:           types.Int64Value(int64(msc.Version)),
+		ComplianceCheckID: types.Int64Value(int64(msc.ComplianceCheckID)),
 	}
 }
 

--- a/internal/provider/munki_script_check_data_source.go
+++ b/internal/provider/munki_script_check_data_source.go
@@ -99,6 +99,11 @@ func (d *MunkiScriptCheckDataSource) Schema(ctx context.Context, req datasource.
 				MarkdownDescription: "Version of the Munki script check.",
 				Computed:            true,
 			},
+			"compliance_check_id": schema.Int64Attribute{
+				Description:         "ID of the compliance check backing this script check.",
+				MarkdownDescription: "`ID` of the compliance check backing this script check.",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/munki_script_check_data_source_test.go
+++ b/internal/provider/munki_script_check_data_source_test.go
@@ -52,6 +52,8 @@ func TestAccMunkiScriptCheckDataSource(t *testing.T) {
 						ds1ResourceName, "excluded_tag_ids.#", "0"),
 					resource.TestCheckResourceAttr(
 						ds1ResourceName, "version", "1"),
+					resource.TestCheckResourceAttrSet(
+						ds1ResourceName, "compliance_check_id"),
 					// Read by ID, no platforms, no tags
 					resource.TestCheckResourceAttrPair(
 						ds2ResourceName, "id", sc2ResourceName, "id"),
@@ -83,6 +85,8 @@ func TestAccMunkiScriptCheckDataSource(t *testing.T) {
 						ds2ResourceName, "excluded_tag_ids.*", excludedTagResourceName, "id"),
 					resource.TestCheckResourceAttr(
 						ds2ResourceName, "version", "1"),
+					resource.TestCheckResourceAttrSet(
+						ds2ResourceName, "compliance_check_id"),
 				),
 			},
 		},

--- a/internal/provider/munki_script_check_resource.go
+++ b/internal/provider/munki_script_check_resource.go
@@ -127,6 +127,11 @@ func (r *MunkiScriptCheckResource) Schema(ctx context.Context, req resource.Sche
 				MarkdownDescription: "Version of the Munki script check.",
 				Computed:            true,
 			},
+			"compliance_check_id": schema.Int64Attribute{
+				Description:         "ID of the compliance check backing this script check.",
+				MarkdownDescription: "`ID` of the compliance check backing this script check.",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/munki_script_check_resource_test.go
+++ b/internal/provider/munki_script_check_resource_test.go
@@ -47,6 +47,8 @@ func TestAccMunkiScriptCheckResource(t *testing.T) {
 						resourceName, "excluded_tag_ids.#", "0"),
 					resource.TestCheckResourceAttr(
 						resourceName, "version", "1"),
+					resource.TestCheckResourceAttrSet(
+						resourceName, "compliance_check_id"),
 				),
 			},
 			// ImportState
@@ -87,6 +89,8 @@ func TestAccMunkiScriptCheckResource(t *testing.T) {
 						resourceName, "excluded_tag_ids.*", excludedTagResourceName, "id"),
 					resource.TestCheckResourceAttr(
 						resourceName, "version", "2"),
+					resource.TestCheckResourceAttrSet(
+						resourceName, "compliance_check_id"),
 				),
 			},
 			// ImportState

--- a/internal/provider/osquery_query.go
+++ b/internal/provider/osquery_query.go
@@ -16,6 +16,7 @@ type osqueryQuery struct {
 	Value                  types.String `tfsdk:"value"`
 	Version                types.Int64  `tfsdk:"version"`
 	ComplianceCheckEnabled types.Bool   `tfsdk:"compliance_check_enabled"`
+	ComplianceCheckID      types.Int64  `tfsdk:"compliance_check_id"`
 	TagID                  types.Int64  `tfsdk:"tag_id"`
 	Scheduling             types.Object `tfsdk:"scheduling"`
 }
@@ -57,6 +58,7 @@ func osqueryQueryForState(oq *goztl.OsqueryQuery) osqueryQuery {
 		Value:                  types.StringValue(oq.Value),
 		Version:                types.Int64Value(int64(oq.Version)),
 		ComplianceCheckEnabled: types.BoolValue(oq.ComplianceCheckEnabled),
+		ComplianceCheckID:      optionalInt64ForState(oq.ComplianceCheckID),
 		TagID:                  optionalInt64ForState(oq.TagID),
 		Scheduling:             scheduling,
 	}

--- a/internal/provider/osquery_query_data_source.go
+++ b/internal/provider/osquery_query_data_source.go
@@ -78,6 +78,11 @@ func (d *OsqueryQueryDataSource) Schema(ctx context.Context, req datasource.Sche
 				MarkdownDescription: "If `true`, the query will be used as compliance check. Defaults to `false`.",
 				Computed:            true,
 			},
+			"compliance_check_id": schema.Int64Attribute{
+				Description:         "ID of the compliance check backing this query, when compliance_check_enabled is true.",
+				MarkdownDescription: "`ID` of the compliance check backing this query, when `compliance_check_enabled` is `true`.",
+				Computed:            true,
+			},
 			"tag_id": schema.Int64Attribute{
 				Description:         "ID of the machine tag that is updated by this query.",
 				MarkdownDescription: "`ID` of the machine tag that is updated by this query.",

--- a/internal/provider/osquery_query_data_source_test.go
+++ b/internal/provider/osquery_query_data_source_test.go
@@ -48,6 +48,8 @@ func TestAccOsqueryQueryDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						ds1ResourceName, "compliance_check_enabled", "false"),
 					resource.TestCheckNoResourceAttr(
+						ds1ResourceName, "compliance_check_id"),
+					resource.TestCheckNoResourceAttr(
 						ds1ResourceName, "tag_id"),
 					resource.TestCheckNoResourceAttr(
 						ds1ResourceName, "scheduling"),
@@ -72,6 +74,8 @@ func TestAccOsqueryQueryDataSource(t *testing.T) {
 						ds2ResourceName, "version", "1"),
 					resource.TestCheckResourceAttr(
 						ds2ResourceName, "compliance_check_enabled", "true"),
+					resource.TestCheckResourceAttrSet(
+						ds2ResourceName, "compliance_check_id"),
 					resource.TestCheckNoResourceAttr(
 						ds1ResourceName, "tag_id"),
 					resource.TestCheckResourceAttr(
@@ -93,6 +97,8 @@ func TestAccOsqueryQueryDataSource(t *testing.T) {
 						ds3ResourceName, "name", q3Name),
 					resource.TestCheckResourceAttr(
 						ds3ResourceName, "compliance_check_enabled", "false"),
+					resource.TestCheckNoResourceAttr(
+						ds3ResourceName, "compliance_check_id"),
 					resource.TestCheckResourceAttrPair(
 						ds3ResourceName, "tag_id", tagResourceName, "id"),
 				),

--- a/internal/provider/osquery_query_resource.go
+++ b/internal/provider/osquery_query_resource.go
@@ -96,6 +96,11 @@ func (r *OsqueryQueryResource) Schema(ctx context.Context, req resource.SchemaRe
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
 			},
+			"compliance_check_id": schema.Int64Attribute{
+				Description:         "ID of the compliance check backing this query, when compliance_check_enabled is true.",
+				MarkdownDescription: "`ID` of the compliance check backing this query, when `compliance_check_enabled` is `true`.",
+				Computed:            true,
+			},
 			"tag_id": schema.Int64Attribute{
 				Description:         "ID of the machine tag that is updated by this query.",
 				MarkdownDescription: "`ID` of the machine tag that is updated by this query.",

--- a/internal/provider/osquery_query_resource_test.go
+++ b/internal/provider/osquery_query_resource_test.go
@@ -41,6 +41,8 @@ func TestAccOsqueryQueryResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "compliance_check_enabled", "false"),
 					resource.TestCheckNoResourceAttr(
+						resourceName, "compliance_check_id"),
+					resource.TestCheckNoResourceAttr(
 						resourceName, "tag_id"),
 					resource.TestCheckNoResourceAttr(
 						resourceName, "scheduling"),
@@ -74,6 +76,8 @@ func TestAccOsqueryQueryResource(t *testing.T) {
 						resourceName, "version", "2"),
 					resource.TestCheckResourceAttr(
 						resourceName, "compliance_check_enabled", "true"),
+					resource.TestCheckResourceAttrSet(
+						resourceName, "compliance_check_id"),
 					resource.TestCheckNoResourceAttr(
 						resourceName, "tag_id"),
 					resource.TestCheckResourceAttr(
@@ -118,6 +122,8 @@ func TestAccOsqueryQueryResource(t *testing.T) {
 						resourceName, "version", "3"),
 					resource.TestCheckResourceAttr(
 						resourceName, "compliance_check_enabled", "false"),
+					resource.TestCheckNoResourceAttr(
+						resourceName, "compliance_check_id"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "tag_id", tagResourceName, "id"),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
Exposes `compliance_check_id` on the JMESPath check, the Munki script check and the Osquery query — resource and data source for each — so a configuration can reference the compliance check backing a check.

Follows zentralopensource/zentral#1589 (the API field) and zentralopensource/goztl#85 (the client field, released as v0.1.78).

## Shape

`Computed` everywhere, as on `zentral_turbo_script` and `zentral_turbo_mscp_check`.

| Resource | Type | Why |
| --- | --- | --- |
| `zentral_jmespath_check` | always set | non-null `OneToOneField` server-side |
| `zentral_munki_script_check` | always set | non-null `OneToOneField` server-side |
| `zentral_osquery_query` | nullable | the compliance check is optional, as on `zentral_turbo_script` |

No `UseStateForUnknown()` on any of them. The plan modifier is for computed attributes other resources reference (the `job_id` case in CLAUDE.md); nothing references these. On the Osquery query it would also be wrong: toggling `compliance_check_enabled` off and on again deletes the compliance check and mints a new one, so the ID is not stable across updates.

## Notes for the reviewer

- `go.mod` bump to goztl v0.1.78 is a separate first commit.
- The acceptance tests assert both branches: `TestCheckResourceAttrSet` where a check always exists, `TestCheckNoResourceAttr` on the Osquery steps where `compliance_check_enabled` is `false`.
- `docs/` is regenerated — `go generate ./...` touches only the six expected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)