### PR TITLE
Mark the secret attributes as sensitive

### DIFF
--- a/docs/data-sources/mdm_ota_enrollment.md
+++ b/docs/data-sources/mdm_ota_enrollment.md
@@ -30,7 +30,7 @@ The data source `zentral_mdm_ota_enrollment` allows details of a MDM OTA enrollm
 - `quota` (Number) The number of times the enrollment can be used.
 - `realm_uuid` (String) `UUID` of the identity realm linked to the OTA enrollment.
 - `scep_issuer_id` (String) `ID` of the MDM SCEP issuer linked to the OTA enrollment.
-- `secret` (String) Enrollment secret.
+- `secret` (String, Sensitive) Enrollment secret.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.
 - `udids` (Set of String) The `UDID`s the enrollment is restricted to.

--- a/docs/data-sources/mdm_recovery_password_config.md
+++ b/docs/data-sources/mdm_recovery_password_config.md
@@ -26,4 +26,4 @@ The data source `zentral_mdm_recovery_password_config` allows details of a MDM r
 - `reveal_rotation_delay` (Number) The delay in minutes after which a recovery password rotation is scheduled once the password has been revealed.
 - `rotate_firmware_password` (Boolean) Set to `true` to rotate the firmware passwords. Defaults to `false`.
 - `rotation_interval_days` (Number) The automatic recovery password rotation interval in days. It has a maximum value of `365`. Defaults to `0` (no automatic rotation).
-- `static_password` (String) The  static password to set for all devices.
+- `static_password` (String) The static password to set for all devices.

--- a/docs/data-sources/mdm_recovery_password_config.md
+++ b/docs/data-sources/mdm_recovery_password_config.md
@@ -26,4 +26,4 @@ The data source `zentral_mdm_recovery_password_config` allows details of a MDM r
 - `reveal_rotation_delay` (Number) The delay in minutes after which a recovery password rotation is scheduled once the password has been revealed.
 - `rotate_firmware_password` (Boolean) Set to `true` to rotate the firmware passwords. Defaults to `false`.
 - `rotation_interval_days` (Number) The automatic recovery password rotation interval in days. It has a maximum value of `365`. Defaults to `0` (no automatic rotation).
-- `static_password` (String) The static password to set for all devices.
+- `static_password` (String, Sensitive) The static password to set for all devices.

--- a/docs/data-sources/monolith_enrollment.md
+++ b/docs/data-sources/monolith_enrollment.md
@@ -26,7 +26,7 @@ The data source `zentral_monolith_enrollment` allows details of a Monolith enrol
 - `meta_business_unit_id` (Number) The `ID` of the meta business unit the machine will be assigned to at enrollment.
 - `plist_url` (String) Plist download URL.
 - `quota` (Number) The number of times the enrollment can be used.
-- `secret` (String) Enrollment secret.
+- `secret` (String, Sensitive) Enrollment secret.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.
 - `udids` (Set of String) The `UDID`s the enrollment is restricted to.

--- a/docs/data-sources/monolith_repository.md
+++ b/docs/data-sources/monolith_repository.md
@@ -33,7 +33,7 @@ The data source `zentral_monolith_repository` allows details of a Monolith repos
 Read-Only:
 
 - `client_id` (String) Client ID of the Azure app registration.
-- `client_secret` (String) Client secret of the Azure app registration.
+- `client_secret` (String, Sensitive) Client secret of the Azure app registration.
 - `container` (String) Name of the blob container.
 - `prefix` (String) Prefix of the Munki repository in the container.
 - `storage_account` (String) Name of the storage account.

--- a/docs/data-sources/munki_enrollment.md
+++ b/docs/data-sources/munki_enrollment.md
@@ -25,7 +25,7 @@ The data source `zentral_munki_enrollment` allows details of a Munki enrollment 
 - `meta_business_unit_id` (Number) The `ID` of the meta business unit the machine will be assigned to at enrollment.
 - `package_url` (String) Package download URL.
 - `quota` (Number) The number of times the enrollment can be used.
-- `secret` (String) Enrollment secret.
+- `secret` (String, Sensitive) Enrollment secret.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.
 - `udids` (Set of String) The `UDID`s the enrollment is restricted to.

--- a/docs/data-sources/osquery_enrollment.md
+++ b/docs/data-sources/osquery_enrollment.md
@@ -28,7 +28,7 @@ The data source `zentral_osquery_enrollment` allows details of a Osquery enrollm
 - `powershell_script_url` (String) Powershell script download URL.
 - `quota` (Number) The number of times the enrollment can be used.
 - `script_url` (String) Linux script download URL.
-- `secret` (String) Enrollment secret.
+- `secret` (String, Sensitive) Enrollment secret.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.
 - `udids` (Set of String) The `UDID`s the enrollment is restricted to.

--- a/docs/data-sources/santa_enrollment.md
+++ b/docs/data-sources/santa_enrollment.md
@@ -26,7 +26,7 @@ The data source `zentral_santa_enrollment` allows details of a Santa enrollment 
 - `meta_business_unit_id` (Number) The `ID` of the meta business unit the machine will be assigned to at enrollment.
 - `plist_url` (String) Plist download URL.
 - `quota` (Number) The number of times the enrollment can be used.
-- `secret` (String) Enrollment secret.
+- `secret` (String, Sensitive) Enrollment secret.
 - `serial_numbers` (Set of String) The serial numbers the enrollment is restricted to.
 - `tag_ids` (Set of Number) The `ID`s of the tags that the machine will get at enrollment.
 - `udids` (Set of String) The `UDID`s the enrollment is restricted to.

--- a/docs/resources/mdm_ota_enrollment.md
+++ b/docs/resources/mdm_ota_enrollment.md
@@ -36,4 +36,4 @@ The resource `zentral_mdm_ota_enrollment` manages MDM OTA enrollments.
 ### Read-Only
 
 - `id` (Number) `ID` of the MDM OTA enrollment.
-- `secret` (String) Enrollment secret.
+- `secret` (String, Sensitive) Enrollment secret.

--- a/docs/resources/mdm_recovery_password_config.md
+++ b/docs/resources/mdm_recovery_password_config.md
@@ -25,7 +25,7 @@ The resource `zentral_mdm_recovery_password_config` manages MDM recovery passwor
 - `reveal_rotation_delay` (Number) The delay in minutes after which a recovery password rotation is scheduled once the password has been revealed. Must be `0`, or between `5` and `1440`, and must be `0` with a static password. Defaults to `0` (no rotation after a reveal). Note that a configuration created outside of Terraform defaults to `60`.
 - `rotate_firmware_password` (Boolean) Set to `true` to rotate the firmware passwords. Defaults to `false`.
 - `rotation_interval_days` (Number) The automatic recovery password rotation interval in days. It has a maximum value of `365`. Defaults to `0` (no automatic rotation).
-- `static_password` (String) The  static password to set for all devices.
+- `static_password` (String) The static password to set for all devices.
 
 ### Read-Only
 

--- a/docs/resources/mdm_recovery_password_config.md
+++ b/docs/resources/mdm_recovery_password_config.md
@@ -25,7 +25,7 @@ The resource `zentral_mdm_recovery_password_config` manages MDM recovery passwor
 - `reveal_rotation_delay` (Number) The delay in minutes after which a recovery password rotation is scheduled once the password has been revealed. Must be `0`, or between `5` and `1440`, and must be `0` with a static password. Defaults to `0` (no rotation after a reveal). Note that a configuration created outside of Terraform defaults to `60`.
 - `rotate_firmware_password` (Boolean) Set to `true` to rotate the firmware passwords. Defaults to `false`.
 - `rotation_interval_days` (Number) The automatic recovery password rotation interval in days. It has a maximum value of `365`. Defaults to `0` (no automatic rotation).
-- `static_password` (String) The static password to set for all devices.
+- `static_password` (String, Sensitive) The static password to set for all devices.
 
 ### Read-Only
 

--- a/docs/resources/monolith_enrollment.md
+++ b/docs/resources/monolith_enrollment.md
@@ -32,5 +32,5 @@ The resource `zentral_monolith_enrollment` manages Monolith enrollments.
 - `configuration_profile_url` (String) Configuration profile download URL.
 - `id` (Number) `ID` of the Monolith enrollment.
 - `plist_url` (String) Plist download URL.
-- `secret` (String) Enrollment secret.
+- `secret` (String, Sensitive) Enrollment secret.
 - `version` (Number) Enrollment version.

--- a/docs/resources/munki_enrollment.md
+++ b/docs/resources/munki_enrollment.md
@@ -31,5 +31,5 @@ The resource `zentral_munki_enrollment` manages Munki enrollments.
 
 - `id` (Number) `ID` of the Munki enrollment.
 - `package_url` (String) Configuration package download URL.
-- `secret` (String) Enrollment secret.
+- `secret` (String, Sensitive) Enrollment secret.
 - `version` (Number) Enrollment version.

--- a/docs/resources/osquery_enrollment.md
+++ b/docs/resources/osquery_enrollment.md
@@ -34,5 +34,5 @@ The resource `zentral_osquery_enrollment` manages Osquery enrollments.
 - `package_url` (String) macOS package download URL.
 - `powershell_script_url` (String) Powershell script download URL.
 - `script_url` (String) Linux script download URL.
-- `secret` (String) Enrollment secret.
+- `secret` (String, Sensitive) Enrollment secret.
 - `version` (Number) Enrollment version.

--- a/docs/resources/santa_enrollment.md
+++ b/docs/resources/santa_enrollment.md
@@ -32,5 +32,5 @@ The resource `zentral_santa_enrollment` manages Santa enrollments.
 - `configuration_profile_url` (String) Configuration profile download URL.
 - `id` (Number) `ID` of the Santa enrollment.
 - `plist_url` (String) Plist download URL.
-- `secret` (String) Enrollment secret.
+- `secret` (String, Sensitive) Enrollment secret.
 - `version` (Number) Enrollment version.

--- a/docs/resources/store.md
+++ b/docs/resources/store.md
@@ -214,7 +214,7 @@ Optional:
 
 - `assume_role_arn` (String) `ARN` of the AWS role to assume.
 - `aws_access_key_id` (String) AWS access key ID.
-- `aws_secret_access_key` (String) AWS secret access key.
+- `aws_secret_access_key` (String, Sensitive) AWS secret access key.
 - `batch_size` (Number) Number of events sent in a single request. Defaults to `1`. Must be between `1` and `500`.
 
 

--- a/internal/provider/mdm_ota_enrollment_data_source.go
+++ b/internal/provider/mdm_ota_enrollment_data_source.go
@@ -76,6 +76,7 @@ func (d *MDMOTAEnrollmentDataSource) Schema(ctx context.Context, req datasource.
 				Description:         "Enrollment secret.",
 				MarkdownDescription: "Enrollment secret.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"meta_business_unit_id": schema.Int64Attribute{
 				Description:         "The ID of the meta business unit the machine will be assigned to at enrollment.",

--- a/internal/provider/mdm_ota_enrollment_resource.go
+++ b/internal/provider/mdm_ota_enrollment_resource.go
@@ -89,6 +89,7 @@ func (r *MDMOTAEnrollmentResource) Schema(ctx context.Context, req resource.Sche
 				Description:         "Enrollment secret.",
 				MarkdownDescription: "Enrollment secret.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"meta_business_unit_id": schema.Int64Attribute{
 				Description:         "The ID of the meta business unit the machine will be assigned to at enrollment.",

--- a/internal/provider/mdm_recovery_password_config_data_source.go
+++ b/internal/provider/mdm_recovery_password_config_data_source.go
@@ -50,6 +50,7 @@ func (d *MDMRecoveryPasswordConfigDataSource) Schema(ctx context.Context, req da
 				Description:         "The static password to set for all devices.",
 				MarkdownDescription: "The static password to set for all devices.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"rotation_interval_days": schema.Int64Attribute{
 				Description:         "The automatic recovery password rotation interval in days. It has a maximum value of 365. Defaults to 0 (no automatic rotation).",

--- a/internal/provider/mdm_recovery_password_config_data_source.go
+++ b/internal/provider/mdm_recovery_password_config_data_source.go
@@ -48,7 +48,7 @@ func (d *MDMRecoveryPasswordConfigDataSource) Schema(ctx context.Context, req da
 			},
 			"static_password": schema.StringAttribute{
 				Description:         "The static password to set for all devices.",
-				MarkdownDescription: "The  static password to set for all devices.",
+				MarkdownDescription: "The static password to set for all devices.",
 				Computed:            true,
 			},
 			"rotation_interval_days": schema.Int64Attribute{

--- a/internal/provider/mdm_recovery_password_config_resource.go
+++ b/internal/provider/mdm_recovery_password_config_resource.go
@@ -63,6 +63,7 @@ func (r *MDMRecoveryPasswordConfigResource) Schema(ctx context.Context, req reso
 				Description:         "The static password to set for all devices.",
 				MarkdownDescription: "The static password to set for all devices.",
 				Optional:            true,
+				Sensitive:           true,
 			},
 			"rotation_interval_days": schema.Int64Attribute{
 				Description:         "The automatic recovery password rotation interval in days. It has a maximum value of 365. Defaults to 0 (no automatic rotation).",

--- a/internal/provider/mdm_recovery_password_config_resource.go
+++ b/internal/provider/mdm_recovery_password_config_resource.go
@@ -61,7 +61,7 @@ func (r *MDMRecoveryPasswordConfigResource) Schema(ctx context.Context, req reso
 			},
 			"static_password": schema.StringAttribute{
 				Description:         "The static password to set for all devices.",
-				MarkdownDescription: "The  static password to set for all devices.",
+				MarkdownDescription: "The static password to set for all devices.",
 				Optional:            true,
 			},
 			"rotation_interval_days": schema.Int64Attribute{

--- a/internal/provider/monolith_enrollment_data_source.go
+++ b/internal/provider/monolith_enrollment_data_source.go
@@ -61,6 +61,7 @@ func (d *MonolithEnrollmentDataSource) Schema(ctx context.Context, req datasourc
 				Description:         "Enrollment secret.",
 				MarkdownDescription: "Enrollment secret.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"meta_business_unit_id": schema.Int64Attribute{
 				Description:         "The ID of the meta business unit the machine will be assigned to at enrollment.",

--- a/internal/provider/monolith_enrollment_resource.go
+++ b/internal/provider/monolith_enrollment_resource.go
@@ -68,6 +68,7 @@ func (r *MonolithEnrollmentResource) Schema(ctx context.Context, req resource.Sc
 				Description:         "Enrollment secret.",
 				MarkdownDescription: "Enrollment secret.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"meta_business_unit_id": schema.Int64Attribute{
 				Description:         "The ID of the meta business unit the machine will be assigned to at enrollment.",

--- a/internal/provider/monolith_repository_data_source.go
+++ b/internal/provider/monolith_repository_data_source.go
@@ -83,6 +83,7 @@ func (d *MonolithRepositoryDataSource) Schema(ctx context.Context, req datasourc
 					"client_secret": schema.StringAttribute{
 						Description:         "Client secret of the Azure app registration.",
 						MarkdownDescription: "Client secret of the Azure app registration.",
+						Sensitive:           true,
 						Computed:            true,
 					},
 				},

--- a/internal/provider/munki_enrollment_data_source.go
+++ b/internal/provider/munki_enrollment_data_source.go
@@ -56,6 +56,7 @@ func (d *MunkiEnrollmentDataSource) Schema(ctx context.Context, req datasource.S
 				Description:         "Enrollment secret.",
 				MarkdownDescription: "Enrollment secret.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"meta_business_unit_id": schema.Int64Attribute{
 				Description:         "The ID of the meta business unit the machine will be assigned to at enrollment.",

--- a/internal/provider/munki_enrollment_resource.go
+++ b/internal/provider/munki_enrollment_resource.go
@@ -63,6 +63,7 @@ func (r *MunkiEnrollmentResource) Schema(ctx context.Context, req resource.Schem
 				Description:         "Enrollment secret.",
 				MarkdownDescription: "Enrollment secret.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"meta_business_unit_id": schema.Int64Attribute{
 				Description:         "The ID of the meta business unit the machine will be assigned to at enrollment.",

--- a/internal/provider/osquery_enrollment_data_source.go
+++ b/internal/provider/osquery_enrollment_data_source.go
@@ -71,6 +71,7 @@ func (d *OsqueryEnrollmentDataSource) Schema(ctx context.Context, req datasource
 				Description:         "Enrollment secret.",
 				MarkdownDescription: "Enrollment secret.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"meta_business_unit_id": schema.Int64Attribute{
 				Description:         "The ID of the meta business unit the machine will be assigned to at enrollment.",

--- a/internal/provider/osquery_enrollment_resource.go
+++ b/internal/provider/osquery_enrollment_resource.go
@@ -81,6 +81,7 @@ func (r *OsqueryEnrollmentResource) Schema(ctx context.Context, req resource.Sch
 				Description:         "Enrollment secret.",
 				MarkdownDescription: "Enrollment secret.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"meta_business_unit_id": schema.Int64Attribute{
 				Description:         "The ID of the meta business unit the machine will be assigned to at enrollment.",

--- a/internal/provider/santa_enrollment_data_source.go
+++ b/internal/provider/santa_enrollment_data_source.go
@@ -61,6 +61,7 @@ func (d *SantaEnrollmentDataSource) Schema(ctx context.Context, req datasource.S
 				Description:         "Enrollment secret.",
 				MarkdownDescription: "Enrollment secret.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"meta_business_unit_id": schema.Int64Attribute{
 				Description:         "The ID of the meta business unit the machine will be assigned to at enrollment.",

--- a/internal/provider/santa_enrollment_resource.go
+++ b/internal/provider/santa_enrollment_resource.go
@@ -68,6 +68,7 @@ func (r *SantaEnrollmentResource) Schema(ctx context.Context, req resource.Schem
 				Description:         "Enrollment secret.",
 				MarkdownDescription: "Enrollment secret.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"meta_business_unit_id": schema.Int64Attribute{
 				Description:         "The ID of the meta business unit the machine will be assigned to at enrollment.",

--- a/internal/provider/store_resource.go
+++ b/internal/provider/store_resource.go
@@ -165,6 +165,7 @@ var kinesisBackendSchema schema.SingleNestedAttribute = schema.SingleNestedAttri
 			Description:         "AWS secret access key.",
 			MarkdownDescription: "AWS secret access key.",
 			Optional:            true,
+			Sensitive:           true,
 		},
 		"assume_role_arn": schema.StringAttribute{
 			Description:         "ARN of the AWS role to assume.",


### PR DESCRIPTION
## Summary

Several secret attributes were missing `Sensitive: true` and were printed in clear text in the `terraform plan` / CLI output. This sweeps all resources **and** data sources for consistency:

- **Enrollment `secret`** (computed): the Santa, Munki, Osquery, Monolith and MDM OTA enrollment resources and data sources — now aligned with `zentral_turbo_enrollment` and the shared enrollment secret schema used by the DEP enrollment.
- **`zentral_store`**: the Kinesis backend `aws_secret_access_key` (the sibling Splunk/Panther/HTTP secrets were already sensitive).
- **`zentral_monolith_repository` data source**: the Azure `client_secret` (already sensitive in the resource and for the S3 secrets).
- **`zentral_mdm_recovery_password_config`** resource and data source: `static_password`.

A first commit also fixes the double space in the `static_password` descriptions.

The cert issuer backends, probe actions (incl. the Slack webhook URL), store HTTP headers and the remaining families were checked and already carry `Sensitive: true`; `docs/` regenerated with `go generate ./...`.

## Test plan

- `go build ./...`, `gofmt -s -l .`, `go test ./...` (in the golang:1.25 container)
- `go generate ./...` — the committed `docs/` match the schemas (zero diff on re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)